### PR TITLE
fix: ignore key-release events on Windows to stop double input

### DIFF
--- a/src/tui/logic/input/mod.rs
+++ b/src/tui/logic/input/mod.rs
@@ -1,4 +1,4 @@
-use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 use crate::keymap::Action;
 use crate::player::Player;
@@ -50,6 +50,11 @@ pub fn handle_key_event(
     data: &mut AppData,
     player: &Player,
 ) -> InputOutcome {
+    if key.kind != KeyEventKind::Press {
+        // Windows emits both Press and Release events per keystroke; Unix
+        // ttys only ever emit Press, so this is a no-op there.
+        return InputOutcome::Continue;
+    }
     if state.quit_confirm_visible {
         return quit::handle_quit_confirm(key, state);
     }


### PR DESCRIPTION
## Summary
- Windows console input emits both `KeyEventKind::Press` and `Release` per keystroke via crossterm; Unix ttys only ever emit `Press`.
- `handle_key_event` never checked `key.kind`, so every keystroke fired its action twice on Windows (double scroll, play/pause instantly cancelling itself).
- Filter out non-`Press` events at the top of `handle_key_event`, before any popup/state handling. No-op on Unix.

Fixes #36

## Test plan
- [x] `cargo build`
- [x] `cargo test` (36 passed, 0 failed, 3 ignored)