### PR TITLE
Start an artist station from search or following

### DIFF
--- a/src/api/calls/related.rs
+++ b/src/api/calls/related.rs
@@ -2,8 +2,8 @@ use std::sync::{Arc, Mutex};
 
 use crate::auth::Token;
 
-use super::super::utils::{access_token, parse_track, response_items};
-use crate::api::Track;
+use super::super::utils::{access_token, parse_str, parse_track, response_items};
+use crate::api::{Artist, Track};
 
 /// Tracks SoundCloud considers related to `track_urn`, playable ones only.
 /// Feeds stations and the end-of-queue autoplay.
@@ -28,4 +28,29 @@ pub async fn fetch_related_tracks(
         .await?;
 
     Ok(response_items(&resp).into_iter().map(|v| parse_track(&v)).collect())
+}
+
+/// Artists SoundCloud considers similar to `user_urn`. There is no public "artist station"
+/// endpoint (that's a private api-v2 resource); this is the closest a public-API client gets,
+/// used to build a station-like mix from the seed artist plus a few of these.
+pub async fn fetch_related_users(
+    token: Arc<Mutex<Token>>,
+    user_urn: String,
+) -> anyhow::Result<Vec<Artist>> {
+    let access_token = access_token(&token);
+
+    let resp: serde_json::Value = reqwest::Client::new()
+        .get(format!("https://api.soundcloud.com/users/{user_urn}/related"))
+        .query(&[("limit", "20"), ("linked_partitioning", "true")])
+        .bearer_auth(access_token)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    Ok(response_items(&resp)
+        .into_iter()
+        .map(|v| Artist { name: parse_str(&v, "username"), urn: parse_str(&v, "urn") })
+        .collect())
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,7 +13,7 @@ pub use calls::playlist_edit::{
     add_track_to_playlist, create_playlist, delete_playlist, remove_track_from_playlist,
 };
 pub use calls::playlists::fetch_playlist_tracks;
-pub use calls::related::fetch_related_tracks;
+pub use calls::related::{fetch_related_tracks, fetch_related_users};
 pub use calls::search::{
     fetch_search_albums, fetch_search_people, fetch_search_playlists, fetch_search_tracks,
 };

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -51,6 +51,7 @@ pub enum Action {
     ToggleShuffle,
     ToggleRepeat,
     ToggleLike,
+    ToggleLikePlaying,
     AddToQueue,
     PlayNext,
     ToggleQueue,
@@ -58,6 +59,7 @@ pub enum Action {
     Search,
     ToggleVisualizer,
     AddToPlaylist,
+    AddToPlaylistPlaying,
     NewPlaylist,
     RemoveFromPlaylist,
     DeletePlaylist,
@@ -65,7 +67,7 @@ pub enum Action {
 }
 
 impl Action {
-    pub const ALL: [Action; 37] = [
+    pub const ALL: [Action; 39] = [
         Action::Quit,
         Action::Help,
         Action::NextTab,
@@ -92,6 +94,7 @@ impl Action {
         Action::ToggleShuffle,
         Action::ToggleRepeat,
         Action::ToggleLike,
+        Action::ToggleLikePlaying,
         Action::AddToQueue,
         Action::PlayNext,
         Action::ToggleQueue,
@@ -99,6 +102,7 @@ impl Action {
         Action::Search,
         Action::ToggleVisualizer,
         Action::AddToPlaylist,
+        Action::AddToPlaylistPlaying,
         Action::NewPlaylist,
         Action::RemoveFromPlaylist,
         Action::DeletePlaylist,
@@ -134,6 +138,7 @@ impl Action {
             Action::ToggleShuffle => "toggle_shuffle",
             Action::ToggleRepeat => "toggle_repeat",
             Action::ToggleLike => "toggle_like",
+            Action::ToggleLikePlaying => "toggle_like_playing",
             Action::AddToQueue => "add_to_queue",
             Action::PlayNext => "play_next",
             Action::ToggleQueue => "toggle_queue",
@@ -141,6 +146,7 @@ impl Action {
             Action::Search => "search",
             Action::ToggleVisualizer => "toggle_visualizer",
             Action::AddToPlaylist => "add_to_playlist",
+            Action::AddToPlaylistPlaying => "add_to_playlist_playing",
             Action::NewPlaylist => "new_playlist",
             Action::RemoveFromPlaylist => "remove_from_playlist",
             Action::DeletePlaylist => "delete_playlist",
@@ -167,7 +173,7 @@ impl Action {
             Action::TertiaryDown => "Move the third pane's selection down (likes of a person)",
             Action::PlayPause => "Play / pause",
             Action::PlaySelected => "Play the selected track",
-            Action::StartStation => "Start a station from the selected track",
+            Action::StartStation => "Start a station from the selected track (or artist)",
             Action::NextTrack => "Next track",
             Action::PrevTrack => "Previous track",
             Action::SeekForward => "Seek forward 10s",
@@ -177,6 +183,7 @@ impl Action {
             Action::ToggleShuffle => "Toggle shuffle",
             Action::ToggleRepeat => "Toggle repeat",
             Action::ToggleLike => "Like / unlike, follow / unfollow the selection",
+            Action::ToggleLikePlaying => "Like / unlike the currently playing track",
             Action::AddToQueue => "Add the selected track to the queue",
             Action::PlayNext => "Play the selected track next",
             Action::ToggleQueue => "Toggle the queue popup",
@@ -184,6 +191,7 @@ impl Action {
             Action::Search => "Search: type a query (Search tab) / filter the list (Library)",
             Action::ToggleVisualizer => "Toggle the visualiser",
             Action::AddToPlaylist => "Add the selected track to a playlist (or a new one)",
+            Action::AddToPlaylistPlaying => "Add the currently playing track to a playlist (or a new one)",
             Action::NewPlaylist => "Create an empty playlist (Playlists tab)",
             Action::RemoveFromPlaylist => "Remove the selected track from your open playlist",
             Action::DeletePlaylist => "Delete the selected playlist of yours",
@@ -226,6 +234,8 @@ pub const DEFAULTS: &[(Action, &[&str])] = &[
     (Action::ToggleShuffle, &["shift+s"]),
     (Action::ToggleRepeat, &["shift+r"]),
     (Action::ToggleLike, &["shift+f"]),
+    // macOS sends Option+F as ƒ unless the terminal maps Option to Alt; bind both.
+    (Action::ToggleLikePlaying, &["alt+f", "ƒ"]),
     (Action::AddToQueue, &["shift+a"]),
     (Action::PlayNext, &["shift+u"]),
     (Action::ToggleQueue, &["shift+q"]),
@@ -233,6 +243,8 @@ pub const DEFAULTS: &[(Action, &[&str])] = &[
     (Action::Search, &["/"]),
     (Action::ToggleVisualizer, &["shift+v"]),
     (Action::AddToPlaylist, &["shift+t"]),
+    // macOS sends Option+T as † unless the terminal maps Option to Alt; bind both.
+    (Action::AddToPlaylistPlaying, &["alt+t", "†"]),
     (Action::NewPlaylist, &["shift+c"]),
     (Action::RemoveFromPlaylist, &["shift+d"]),
     (Action::DeletePlaylist, &["shift+x"]),
@@ -629,6 +641,12 @@ mod tests {
         assert_eq!(km.action(&key(KeyCode::Char('j'), KeyModifiers::ALT)), Some(Action::TertiaryDown));
         assert_eq!(km.action(&key(KeyCode::Char('∆'), KeyModifiers::NONE)), Some(Action::TertiaryDown));
         assert_eq!(km.action(&key(KeyCode::Char('˚'), KeyModifiers::NONE)), Some(Action::TertiaryUp));
+        // Option+F on macOS, with and without the terminal mapping Option to Alt.
+        assert_eq!(km.action(&key(KeyCode::Char('f'), KeyModifiers::ALT)), Some(Action::ToggleLikePlaying));
+        assert_eq!(km.action(&key(KeyCode::Char('ƒ'), KeyModifiers::NONE)), Some(Action::ToggleLikePlaying));
+        // Option+T on macOS, with and without the terminal mapping Option to Alt.
+        assert_eq!(km.action(&key(KeyCode::Char('t'), KeyModifiers::ALT)), Some(Action::AddToPlaylistPlaying));
+        assert_eq!(km.action(&key(KeyCode::Char('†'), KeyModifiers::NONE)), Some(Action::AddToPlaylistPlaying));
     }
 
     #[test]

--- a/src/tui/logic/input/commands.rs
+++ b/src/tui/logic/input/commands.rs
@@ -6,6 +6,7 @@ use crate::tui::logic::state::{AppData, AppState, ConfirmAction, Engagement, Fol
 use crate::player::Player;
 use crate::tui::logic::utils::{active_tracks, build_queue};
 use crate::tui::logic::utils::build_search_matches;
+use crate::tui::logic::utils::queued_from_current;
 use crate::tui::logic::utils::{soundcloud_id_from_urn, soundcloud_playlist_id_from_tracks_uri};
 
 use super::helpers::{filtered_row, reset_search_rows};
@@ -54,6 +55,10 @@ pub(crate) fn run_command(
         Action::ToggleLike => {
             enqueue_like_follow_selected(state, data);
         }
+        Action::ToggleLikePlaying => {
+            let playing = queued_from_current(state, data).map(|q| q.track);
+            toggle_track_like(playing, state, data);
+        }
         Action::Search => {
             if state.selected_tab == 1 {
                 state.search_typing = true;
@@ -82,6 +87,11 @@ pub(crate) fn run_command(
         // Playlist management. Both destructive actions go through the confirm popup.
         Action::AddToPlaylist => {
             if let Some(queued) = selected_queued(state, data) {
+                super::playlist_picker::open_picker(state, queued.track);
+            }
+        }
+        Action::AddToPlaylistPlaying => {
+            if let Some(queued) = queued_from_current(state, data) {
                 super::playlist_picker::open_picker(state, queued.track);
             }
         }

--- a/src/tui/logic/input/movement.rs
+++ b/src/tui/logic/input/movement.rs
@@ -134,7 +134,9 @@ fn handle_album_down(key: KeyEvent, state: &mut AppState, data: &mut AppData) {
 
 fn handle_following_down(key: KeyEvent, state: &mut AppState, data: &mut AppData) {
     if key.modifiers.contains(KeyModifiers::SHIFT) {
-        step(&mut state.selected_row, data.following.len(), 1, &mut data.following_state);
+        if step(&mut state.selected_row, data.following.len(), 1, &mut data.following_state) {
+            state.following_tracks_focus = FollowingTracksFocus::Artists;
+        }
     } else if key.modifiers.contains(KeyModifiers::ALT) {
         if page(&mut state.selected_following_track_row, data.following_tracks.len(), 10, &mut data.following_tracks_state) {
             state.following_tracks_focus = FollowingTracksFocus::Published;
@@ -195,7 +197,9 @@ fn handle_album_up(key: KeyEvent, state: &mut AppState, data: &mut AppData) {
 
 fn handle_following_up(key: KeyEvent, state: &mut AppState, data: &mut AppData) {
     if key.modifiers.contains(KeyModifiers::SHIFT) {
-        step(&mut state.selected_row, data.following.len(), -1, &mut data.following_state);
+        if step(&mut state.selected_row, data.following.len(), -1, &mut data.following_state) {
+            state.following_tracks_focus = FollowingTracksFocus::Artists;
+        }
     } else if key.modifiers.contains(KeyModifiers::ALT) {
         state.following_tracks_focus = FollowingTracksFocus::Published;
         page(&mut state.selected_following_track_row, data.following_tracks.len(), -10, &mut data.following_tracks_state);
@@ -252,7 +256,9 @@ fn handle_search_down(key: KeyEvent, state: &mut AppState, data: &mut AppData) {
         }
         3 => {
             if key.modifiers.contains(KeyModifiers::SHIFT) {
-                step(&mut state.selected_row, data.search_people.len(), 1, &mut data.search_people_state);
+                if step(&mut state.selected_row, data.search_people.len(), 1, &mut data.search_people_state) {
+                    state.search_people_tracks_focus = FollowingTracksFocus::Artists;
+                }
             } else if key.modifiers.contains(KeyModifiers::ALT) {
                 if page(&mut state.search_selected_person_track_row, data.search_people_tracks.len(), 10, &mut data.search_people_tracks_state) {
                     state.search_people_tracks_focus = FollowingTracksFocus::Published;
@@ -295,7 +301,9 @@ fn handle_search_up(key: KeyEvent, state: &mut AppState, data: &mut AppData) {
         }
         3 => {
             if key.modifiers.contains(KeyModifiers::SHIFT) {
-                step(&mut state.selected_row, data.search_people.len(), -1, &mut data.search_people_state);
+                if step(&mut state.selected_row, data.search_people.len(), -1, &mut data.search_people_state) {
+                    state.search_people_tracks_focus = FollowingTracksFocus::Artists;
+                }
             } else if key.modifiers.contains(KeyModifiers::ALT) {
                 state.search_people_tracks_focus = FollowingTracksFocus::Published;
                 page(&mut state.search_selected_person_track_row, data.search_people_tracks.len(), -10, &mut data.search_people_tracks_state);

--- a/src/tui/logic/input/playback.rs
+++ b/src/tui/logic/input/playback.rs
@@ -1,11 +1,28 @@
 use super::InputOutcome;
 use super::helpers::filtered_row;
-use crate::api::Track;
+use crate::api::{Artist, Track};
 use crate::tui::logic::state::{AppData, AppState, PlaybackSource, FollowingTracksFocus};
 use crate::player::Player;
 use crate::tui::logic::utils::{build_queue, enter_radio, queued_from_current};
 
 use super::queue::selected_queued;
+
+/// The artist row itself, when it (not either track pane) has the cursor.
+fn focused_artist(state: &AppState, data: &AppData) -> Option<Artist> {
+    if state.selected_tab == 0
+        && state.selected_subtab == 3
+        && state.following_tracks_focus == FollowingTracksFocus::Artists
+    {
+        data.following.get(state.selected_row).cloned()
+    } else if state.selected_tab == 1
+        && state.selected_searchfilter == 3
+        && state.search_people_tracks_focus == FollowingTracksFocus::Artists
+    {
+        data.search_people.get(state.selected_row).cloned()
+    } else {
+        None
+    }
+}
 
 pub(crate) fn handle_enter(
     state: &mut AppState,
@@ -29,11 +46,17 @@ pub(crate) fn handle_enter(
 }
 
 /// Shift+Enter (or Shift+G): play the selected track as a station — related tracks follow.
+/// On a focused artist row, starts an artist station instead; the loop fetches it in the
+/// background (there is no synchronous path from here to the network).
 pub(crate) fn handle_station(
     state: &mut AppState,
     data: &mut AppData,
     player: &Player,
 ) -> InputOutcome {
+    if let Some(artist) = focused_artist(state, data) {
+        state.artist_station_request = Some(artist);
+        return InputOutcome::Continue;
+    }
     let Some(queued) = selected_queued(state, data) else {
         return InputOutcome::Continue;
     };
@@ -45,7 +68,7 @@ pub(crate) fn handle_station(
     }
     state.manual_queue.clear();
     player.play(queued.track.clone());
-    enter_radio(state, data, queued.track);
+    enter_radio(state, data, vec![queued.track]);
     InputOutcome::Continue
 }
 

--- a/src/tui/logic/mod.rs
+++ b/src/tui/logic/mod.rs
@@ -6,12 +6,14 @@ pub(crate) mod utils;
 use crate::api::{
     Lyrics, fetch_lyrics,
     add_track_to_playlist, create_playlist, delete_playlist, remove_track_from_playlist,
-    fetch_related_tracks,
+    fetch_related_tracks, fetch_related_users,
     API, Activity, Album, Artist, Playlist, Track, engage, fetch_playlist_tracks,
     fetch_search_albums, fetch_search_people, fetch_search_playlists, fetch_search_tracks,
     fetch_user_tracks,
 };
+use crate::auth::Token;
 use crate::player::Player;
+use rand::seq::SliceRandom;
 use ratatui::crossterm::{
     event::{KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
     execute,
@@ -40,7 +42,7 @@ use self::filtering::{build_filtered_views, clamp_selection, is_filter_active};
 use self::input::helpers::reset_search_rows;
 use self::input::{InputOutcome, handle_key_event, next_track, prev_track, toggle_play_pause};
 use crate::media::{Media, MediaCommand};
-use self::state::{AppData, AppState, Engagement, FollowingTracksFocus, LyricsStatus, PlaybackSource, PlaylistEdit};
+use self::state::{AppData, AppState, Engagement, LyricsStatus, PlaybackSource, PlaylistEdit};
 use self::utils::{
     enter_radio,
     active_tracks, append_feed_tracks, play_queued_track, queued_from_current,
@@ -91,6 +93,9 @@ enum Msg {
     FeedQueue(u64, Vec<Track>),
     /// Related tracks for the radio seed, to append to the queue.
     Related(u64, Vec<Track>),
+    /// A mix built for an artist station: the seed artist plus a few related artists,
+    /// one playable track apiece.
+    ArtistStation(u64, Vec<Track>),
     /// A playlist the user just created, to show at the top of the library.
     PlaylistCreated(Playlist),
     /// Lyrics lookup result for a track URN (`None` = nothing found).
@@ -160,6 +165,68 @@ fn spawn_tracks(
             let _ = tx.send(wrap(request_id, tracks));
         }
     })
+}
+
+/// Up to this many of the seed artist's own tracks go into a station mix.
+const ARTIST_STATION_OWN_TRACKS: usize = 15;
+/// Total tracks in a station mix.
+const ARTIST_STATION_SIZE: usize = 50;
+/// How many related artists to pull tracks from, to fill out the rest of the mix.
+const ARTIST_STATION_RELATED_ARTISTS: usize = 10;
+/// Tracks taken from each related artist's own catalog.
+const ARTIST_STATION_TRACKS_PER_RELATED_ARTIST: usize = 3;
+
+/// A 50-track mix for an artist station: up to 15 of the seed artist's own tracks, the rest
+/// backfilled from SoundCloud's track-level "related" recommendations plus a few tracks apiece
+/// from artists SoundCloud considers similar — the closest a public-API client gets to
+/// SoundCloud's own (private-API) "Artist station". Failures for individual sources are
+/// swallowed; a partial mix (down to just the seed artist) still beats none.
+async fn fetch_artist_station_tracks(token: Arc<Mutex<Token>>, seed_urn: String) -> anyhow::Result<Vec<Track>> {
+    let seed_tracks = fetch_user_tracks(Arc::clone(&token), seed_urn.clone(), "tracks")
+        .await
+        .unwrap_or_default();
+
+    let mut own_tracks: Vec<Track> = seed_tracks.iter().filter(|t| t.is_playable()).cloned().collect();
+    own_tracks.shuffle(&mut rand::thread_rng());
+    own_tracks.truncate(ARTIST_STATION_OWN_TRACKS);
+    let mut seen: std::collections::HashSet<String> =
+        own_tracks.iter().map(|t| t.track_urn.clone()).collect();
+
+    let related_users = fetch_related_users(Arc::clone(&token), seed_urn.clone())
+        .await
+        .unwrap_or_default();
+
+    let mut fetches = tokio::task::JoinSet::new();
+    if let Some(track_urn) = seed_tracks.iter().find(|t| t.is_playable()).map(|t| t.track_urn.clone()) {
+        let token = Arc::clone(&token);
+        fetches.spawn(async move { fetch_related_tracks(token, track_urn).await.unwrap_or_default() });
+    }
+    for artist_urn in related_users.into_iter().take(ARTIST_STATION_RELATED_ARTISTS).map(|a| a.urn) {
+        let token = Arc::clone(&token);
+        fetches.spawn(async move {
+            let mut tracks = fetch_user_tracks(token, artist_urn, "tracks").await.unwrap_or_default();
+            tracks.retain(Track::is_playable);
+            tracks.truncate(ARTIST_STATION_TRACKS_PER_RELATED_ARTIST);
+            tracks
+        });
+    }
+
+    let mut related_pool = Vec::new();
+    while let Some(result) = fetches.join_next().await {
+        let Ok(tracks) = result else { continue };
+        for track in tracks {
+            if track.is_playable() && seen.insert(track.track_urn.clone()) {
+                related_pool.push(track);
+            }
+        }
+    }
+    related_pool.shuffle(&mut rand::thread_rng());
+    related_pool.truncate(ARTIST_STATION_SIZE.saturating_sub(own_tracks.len()));
+
+    let mut tracks = own_tracks;
+    tracks.extend(related_pool);
+    tracks.shuffle(&mut rand::thread_rng());
+    Ok(tracks)
 }
 
 fn start(
@@ -327,6 +394,18 @@ fn start(
                             state.current_playing_index = Some(next_idx);
                             state.radio_waiting = false;
                         }
+                    }
+                }
+                Msg::ArtistStation(id, tracks) => {
+                    if id == state.artist_station_fetch.request_id
+                        && let Some(seed) = tracks.first().cloned()
+                    {
+                        if let Some(current) = queued_from_current(&state, &data) {
+                            state.playback_history.push(current);
+                        }
+                        state.manual_queue.clear();
+                        player.play(seed);
+                        enter_radio(&mut state, &mut data, tracks);
                     }
                 }
                 Msg::PlaylistCreated(playlist) => {
@@ -533,7 +612,9 @@ fn start(
 
         if state.selected_tab == 0 && state.selected_subtab == 3 {
             let selected = following_ref.get(state.selected_row).map(|a| a.urn.clone());
-            let reset = state.following_tracks_fetch.refetch(
+            // Switching artists only happens via Shift+Up/Down, which already sets the focus
+            // (Artists, or a stale Published/Likes from before); nothing here should override it.
+            state.following_tracks_fetch.refetch(
                 &mut data.following_tracks,
                 &mut data.following_tracks_state,
                 &mut data.following_tracks_user_urn,
@@ -545,9 +626,6 @@ fn start(
                     Msg::FollowingTracks,
                 ),
             );
-            if reset {
-                state.following_tracks_focus = FollowingTracksFocus::Published;
-            }
             state.following_likes_fetch.refetch(
                 &mut data.following_likes_tracks,
                 &mut data.following_likes_state,
@@ -605,6 +683,18 @@ fn start(
                         Msg::Related,
                     ));
                 }
+
+        // Shift+Enter on a focused artist row: fetch its station mix in the background, then
+        // Msg::ArtistStation starts playback once it lands.
+        if let Some(artist) = state.artist_station_request.take() {
+            state.artist_station_fetch.cancel();
+            let id = state.artist_station_fetch.request_id;
+            state.artist_station_fetch.task = Some(spawn_tracks(
+                &async_rt, &tx, id,
+                fetch_artist_station_tracks(auth(), artist.urn),
+                Msg::ArtistStation,
+            ));
+        }
 
         // Enter in the feed: keep the queue going with the items after the one playing, in
         // feed order. Track items are appended at once; sets are fetched one at a time.
@@ -772,7 +862,9 @@ fn start(
 
         if state.selected_tab == 1 && state.selected_searchfilter == 3 {
             let selected = data.search_people.get(state.selected_row).map(|a| a.urn.clone());
-            let reset = state.search_people_tracks_fetch.refetch(
+            // Switching people only happens via Shift+Up/Down, which already sets the focus;
+            // nothing here should override it.
+            state.search_people_tracks_fetch.refetch(
                 &mut data.search_people_tracks,
                 &mut data.search_people_tracks_state,
                 &mut data.search_people_tracks_user_urn,
@@ -784,9 +876,6 @@ fn start(
                     Msg::SearchPeopleTracks,
                 ),
             );
-            if reset {
-                state.search_people_tracks_focus = FollowingTracksFocus::Published;
-            }
             state.search_people_likes_fetch.refetch(
                 &mut data.search_people_likes_tracks,
                 &mut data.search_people_likes_state,
@@ -973,7 +1062,7 @@ fn start(
                             // The list is running out: hand over to related tracks now so the
                             // radio fetch lands before this track ends.
                             None if state.playback_source != PlaybackSource::Radio => {
-                                enter_radio(&mut state, &mut data, current_track.clone());
+                                enter_radio(&mut state, &mut data, vec![current_track.clone()]);
                             }
                             None => {}
                         }
@@ -1015,7 +1104,7 @@ fn start(
                             // Nothing queued: related tracks are (or are about to be) on
                             // their way; Msg::Related starts the next one.
                             if state.playback_source != PlaybackSource::Radio {
-                                enter_radio(&mut state, &mut data, current_track.clone());
+                                enter_radio(&mut state, &mut data, vec![current_track.clone()]);
                             }
                             state.radio_waiting = true;
                         }

--- a/src/tui/logic/state.rs
+++ b/src/tui/logic/state.rs
@@ -88,6 +88,8 @@ pub enum FollowingTracksFocus {
     #[default]
     Published,
     Likes,
+    /// The artist name list itself, not either track pane.
+    Artists,
 }
 
 /// A like/follow request; the same value comes back once the server accepted it
@@ -344,6 +346,9 @@ pub struct AppState {
     pub radio_fetched_for: Option<String>,
     /// The radio queue ran dry before related tracks arrived; play as soon as they do.
     pub radio_waiting: bool,
+    /// Set by Shift+Enter on a focused artist row; the loop fetches its station tracks from here.
+    pub artist_station_request: Option<Artist>,
+    pub artist_station_fetch: FetchTask,
     /// Set by Enter in the feed: index of the activity being played; the loop expands from there.
     pub feed_expand_from: Option<usize>,
     pub progress: u64,

--- a/src/tui/logic/utils.rs
+++ b/src/tui/logic/utils.rs
@@ -385,16 +385,17 @@ pub(crate) fn active_tracks<'a>(state: &AppState, data: &'a AppData) -> &'a [Tra
     }
 }
 
-/// Hand playback over to related tracks, seeded by `seed` (the track playing now, index 0).
-/// The main loop notices the near-empty radio queue and fetches related tracks for the seed.
-pub(crate) fn enter_radio(state: &mut AppState, data: &mut AppData, seed: Track) {
+/// Hand playback over to related tracks, seeded by `seeds` (index 0 is playing now). A single
+/// seed leaves nothing queued, so the main loop's near-empty check fires right away and fetches
+/// related tracks for it; a pre-built mix (an artist station) plays through those first.
+pub(crate) fn enter_radio(state: &mut AppState, data: &mut AppData, seeds: Vec<Track>) {
     state.playback_source = PlaybackSource::Radio;
     state.override_playing = None;
     state.current_playing_index = Some(0);
-    state.auto_queue.clear();
     state.radio_fetched_for = None;
     state.radio_waiting = false;
-    data.playback_tracks = vec![seed];
+    state.auto_queue = build_queue(0, &seeds, state.shuffle_enabled);
+    data.playback_tracks = seeds;
     data.playback_playlist_uri = None;
     data.playback_album_uri = None;
     data.playback_following_user_urn = None;

--- a/src/tui/render/tabs/library.rs
+++ b/src/tui/render/tabs/library.rs
@@ -198,12 +198,17 @@ pub fn render_library(
         _ => vec![],
     };
 
+    let artists_focused = selected_subtab == 3 && state.following_tracks_focus == FollowingTracksFocus::Artists;
     let rows: Vec<_> = rows
         .into_iter()
         .enumerate()
         .map(|(i, row)| {
             if i == selected_row {
-                row.style(Style::default().bg(theme::current().muted).fg(theme::current().selection_fg))
+                if artists_focused {
+                    row.style(Style::default().bg(theme::current().selection_bg).fg(theme::current().fg))
+                } else {
+                    row.style(Style::default().bg(theme::current().muted).fg(theme::current().selection_fg))
+                }
             } else {
                 row
             }

--- a/src/tui/render/tabs/search.rs
+++ b/src/tui/render/tabs/search.rs
@@ -232,6 +232,7 @@ pub fn render_search(
         let left_col_widths = vec![Constraint::Length(1), Constraint::Percentage(100)];
         let left_min_widths = calculate_min_widths(&left_col_widths, columns[0].width as usize);
 
+        let people_focus_is_artists = state.search_people_tracks_focus == FollowingTracksFocus::Artists;
         let left_rows = data.search_people
             .iter()
             .enumerate()
@@ -246,7 +247,11 @@ pub fn render_search(
                     truncate_with_ellipsis(&artist.name, left_min_widths[1]),
                 ]);
                 if i == selected_row {
-                    row = row.style(Style::default().bg(theme::current().muted).fg(theme::current().selection_fg));
+                    row = if people_focus_is_artists {
+                        row.style(Style::default().bg(theme::current().selection_bg).fg(theme::current().fg))
+                    } else {
+                        row.style(Style::default().bg(theme::current().muted).fg(theme::current().selection_fg))
+                    };
                 }
                 row
             })


### PR DESCRIPTION
## Summary
- Shift+Enter on a focused artist row (Following list, People search) starts a station for them: up to 15 of their own tracks plus a backfill of related tracks/artists (there's no public-API artist-station endpoint, so this is the closest approximation), fed into the existing radio queue so it keeps going algorithmically once the mix runs out.
- Fixes the artist row never showing the active (blue) cursor: a reactive fetch block was snapping focus back to the tracks pane on every Shift+Up/Down artist change, undoing the new focus state.
- Adds Alt+F / Alt+T to like / add-to-playlist the *currently playing* track (vs. Shift+F / Shift+T for the selected one), with the macOS Option-key fallback glyphs (ƒ / †) the existing Alt+K/Alt+J bindings already needed.

Related to #27 — doesn't add URL/argument-based station playback (deliberately, per discussion on that issue), but covers the same underlying want through the TUI instead.

## Test plan
- [x] `cargo test` (36 passed)
- [x] `cargo check`
- [x] Manual: Search → People, Shift+Down onto an artist (cursor goes blue), Shift+Enter starts their station
- [x] Manual: Alt+F / Alt+T while a track is playing