### PR TITLE
Confirm modal: honour keymap-bound left/right, not just arrows

### DIFF
--- a/src/tui/logic/input/confirm.rs
+++ b/src/tui/logic/input/confirm.rs
@@ -1,16 +1,9 @@
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
 use super::InputOutcome;
-use crate::keymap::{Action, Keymap};
+use super::helpers::toggles_binary_choice;
 use crate::tui::logic::state::{AppData, AppState, ConfirmAction, PlaylistEdit, clamp_row};
 use crate::tui::logic::utils::{bump_track_count, soundcloud_playlist_id_from_tracks_uri};
-
-/// Arrow keys always toggle Yes/No, plus whatever the user has bound to left/right
-/// (default h/l) so a Vim-bound user doesn't have to reach for arrows here.
-fn toggles_confirm_selection(key: &KeyEvent, keymap: &Keymap) -> bool {
-    matches!(key.code, KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down)
-        || matches!(keymap.action(key), Some(Action::SubTabLeft | Action::SubTabRight))
-}
 
 /// Yes / No popup for destructive playlist actions. Owns every key while open.
 pub(crate) fn handle_confirm_input(
@@ -28,7 +21,7 @@ pub(crate) fn handle_confirm_input(
                 perform(action, state, data);
             }
         }
-        _ if toggles_confirm_selection(&key, &state.keymap) => {
+        _ if toggles_binary_choice(&key, &state.keymap) => {
             state.confirm_selected = if state.confirm_selected == 0 { 1 } else { 0 };
         }
         _ => {}
@@ -74,42 +67,5 @@ fn perform(action: ConfirmAction, state: &mut AppState, data: &mut AppData) {
                 state.playlist_edit_queue.push_back(PlaylistEdit::Delete { playlist_id });
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ratatui::crossterm::event::KeyModifiers;
-
-    fn key(code: KeyCode) -> KeyEvent {
-        KeyEvent::new(code, KeyModifiers::NONE)
-    }
-
-    #[test]
-    fn arrows_and_keymap_bound_left_right_toggle_but_other_keys_dont() {
-        let km = Keymap::default();
-        assert!(toggles_confirm_selection(&key(KeyCode::Left), &km));
-        assert!(toggles_confirm_selection(&key(KeyCode::Right), &km));
-        assert!(toggles_confirm_selection(&key(KeyCode::Up), &km));
-        assert!(toggles_confirm_selection(&key(KeyCode::Down), &km));
-        // Default keymap: SubTabLeft/SubTabRight are h/l.
-        assert!(toggles_confirm_selection(&key(KeyCode::Char('h')), &km));
-        assert!(toggles_confirm_selection(&key(KeyCode::Char('l')), &km));
-        assert!(!toggles_confirm_selection(&key(KeyCode::Char('j')), &km));
-        assert!(!toggles_confirm_selection(&key(KeyCode::Enter), &km));
-    }
-
-    #[test]
-    fn rebound_left_right_keys_are_honoured() {
-        let mut km = Keymap::default();
-        km.clear(Action::SubTabLeft);
-        km.clear(Action::SubTabRight);
-        assert!(km.add_chord(Action::SubTabLeft, crate::keymap::Chord::parse("a").unwrap()).is_ok());
-        assert!(km.add_chord(Action::SubTabRight, crate::keymap::Chord::parse("d").unwrap()).is_ok());
-        assert!(toggles_confirm_selection(&key(KeyCode::Char('a')), &km));
-        assert!(toggles_confirm_selection(&key(KeyCode::Char('d')), &km));
-        // The old default no longer does anything for this action.
-        assert!(!toggles_confirm_selection(&key(KeyCode::Char('h')), &km));
     }
 }

--- a/src/tui/logic/input/confirm.rs
+++ b/src/tui/logic/input/confirm.rs
@@ -1,8 +1,16 @@
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
 use super::InputOutcome;
+use crate::keymap::{Action, Keymap};
 use crate::tui::logic::state::{AppData, AppState, ConfirmAction, PlaylistEdit, clamp_row};
 use crate::tui::logic::utils::{bump_track_count, soundcloud_playlist_id_from_tracks_uri};
+
+/// Arrow keys always toggle Yes/No, plus whatever the user has bound to left/right
+/// (default h/l) so a Vim-bound user doesn't have to reach for arrows here.
+fn toggles_confirm_selection(key: &KeyEvent, keymap: &Keymap) -> bool {
+    matches!(key.code, KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down)
+        || matches!(keymap.action(key), Some(Action::SubTabLeft | Action::SubTabRight))
+}
 
 /// Yes / No popup for destructive playlist actions. Owns every key while open.
 pub(crate) fn handle_confirm_input(
@@ -12,9 +20,6 @@ pub(crate) fn handle_confirm_input(
 ) -> InputOutcome {
     match key.code {
         KeyCode::Esc => state.confirm = None,
-        KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down => {
-            state.confirm_selected = if state.confirm_selected == 0 { 1 } else { 0 };
-        }
         KeyCode::Enter => {
             let action = state.confirm.take();
             if state.confirm_selected == 0
@@ -22,6 +27,9 @@ pub(crate) fn handle_confirm_input(
             {
                 perform(action, state, data);
             }
+        }
+        _ if toggles_confirm_selection(&key, &state.keymap) => {
+            state.confirm_selected = if state.confirm_selected == 0 { 1 } else { 0 };
         }
         _ => {}
     }
@@ -66,5 +74,42 @@ fn perform(action: ConfirmAction, state: &mut AppState, data: &mut AppData) {
                 state.playlist_edit_queue.push_back(PlaylistEdit::Delete { playlist_id });
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn arrows_and_keymap_bound_left_right_toggle_but_other_keys_dont() {
+        let km = Keymap::default();
+        assert!(toggles_confirm_selection(&key(KeyCode::Left), &km));
+        assert!(toggles_confirm_selection(&key(KeyCode::Right), &km));
+        assert!(toggles_confirm_selection(&key(KeyCode::Up), &km));
+        assert!(toggles_confirm_selection(&key(KeyCode::Down), &km));
+        // Default keymap: SubTabLeft/SubTabRight are h/l.
+        assert!(toggles_confirm_selection(&key(KeyCode::Char('h')), &km));
+        assert!(toggles_confirm_selection(&key(KeyCode::Char('l')), &km));
+        assert!(!toggles_confirm_selection(&key(KeyCode::Char('j')), &km));
+        assert!(!toggles_confirm_selection(&key(KeyCode::Enter), &km));
+    }
+
+    #[test]
+    fn rebound_left_right_keys_are_honoured() {
+        let mut km = Keymap::default();
+        km.clear(Action::SubTabLeft);
+        km.clear(Action::SubTabRight);
+        assert!(km.add_chord(Action::SubTabLeft, crate::keymap::Chord::parse("a").unwrap()).is_ok());
+        assert!(km.add_chord(Action::SubTabRight, crate::keymap::Chord::parse("d").unwrap()).is_ok());
+        assert!(toggles_confirm_selection(&key(KeyCode::Char('a')), &km));
+        assert!(toggles_confirm_selection(&key(KeyCode::Char('d')), &km));
+        // The old default no longer does anything for this action.
+        assert!(!toggles_confirm_selection(&key(KeyCode::Char('h')), &km));
     }
 }

--- a/src/tui/logic/input/helpers.rs
+++ b/src/tui/logic/input/helpers.rs
@@ -1,4 +1,7 @@
+use ratatui::crossterm::event::{KeyCode, KeyEvent};
+
 use crate::api::Track;
+use crate::keymap::{Action, Keymap};
 use crate::tui::logic::state::{AppState, FollowingTracksFocus, PlaybackSource, QueuedTrack};
 
 impl QueuedTrack {
@@ -51,4 +54,53 @@ pub(crate) fn reset_search_rows(state: &mut AppState) {
     state.search_selected_person_track_row = 0;
     state.search_selected_person_like_row = 0;
     state.search_people_tracks_focus = FollowingTracksFocus::Published;
+}
+
+/// Arrow keys always flip a two-option Yes/No choice, plus whatever the user has bound to
+/// left/right/up/down (default h/j/k/l) so a Vim-bound user doesn't have to reach for arrows.
+pub(crate) fn toggles_binary_choice(key: &KeyEvent, keymap: &Keymap) -> bool {
+    matches!(key.code, KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down)
+        || matches!(
+            keymap.action(key),
+            Some(Action::SubTabLeft | Action::SubTabRight | Action::Up | Action::Down)
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn arrows_and_keymap_bound_hjkl_toggle_but_other_keys_dont() {
+        let km = Keymap::default();
+        assert!(toggles_binary_choice(&key(KeyCode::Left), &km));
+        assert!(toggles_binary_choice(&key(KeyCode::Right), &km));
+        assert!(toggles_binary_choice(&key(KeyCode::Up), &km));
+        assert!(toggles_binary_choice(&key(KeyCode::Down), &km));
+        // Default keymap: SubTabLeft/SubTabRight/Up/Down are h/l/k/j.
+        assert!(toggles_binary_choice(&key(KeyCode::Char('h')), &km));
+        assert!(toggles_binary_choice(&key(KeyCode::Char('j')), &km));
+        assert!(toggles_binary_choice(&key(KeyCode::Char('k')), &km));
+        assert!(toggles_binary_choice(&key(KeyCode::Char('l')), &km));
+        assert!(!toggles_binary_choice(&key(KeyCode::Char('x')), &km));
+        assert!(!toggles_binary_choice(&key(KeyCode::Enter), &km));
+    }
+
+    #[test]
+    fn rebound_direction_keys_are_honoured() {
+        let mut km = Keymap::default();
+        km.clear(Action::SubTabLeft);
+        km.clear(Action::SubTabRight);
+        assert!(km.add_chord(Action::SubTabLeft, crate::keymap::Chord::parse("a").unwrap()).is_ok());
+        assert!(km.add_chord(Action::SubTabRight, crate::keymap::Chord::parse("d").unwrap()).is_ok());
+        assert!(toggles_binary_choice(&key(KeyCode::Char('a')), &km));
+        assert!(toggles_binary_choice(&key(KeyCode::Char('d')), &km));
+        // The old default no longer does anything for this action.
+        assert!(!toggles_binary_choice(&key(KeyCode::Char('h')), &km));
+    }
 }

--- a/src/tui/logic/input/quit.rs
+++ b/src/tui/logic/input/quit.rs
@@ -1,16 +1,13 @@
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
 use super::InputOutcome;
+use super::helpers::toggles_binary_choice;
 use crate::tui::logic::state::AppState;
 
 pub(crate) fn handle_quit_confirm(key: KeyEvent, state: &mut AppState) -> InputOutcome {
     match key.code {
         KeyCode::Esc => {
             state.quit_confirm_visible = false;
-            InputOutcome::Continue
-        }
-        KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down => {
-            state.quit_confirm_selected = if state.quit_confirm_selected == 0 { 1 } else { 0 };
             InputOutcome::Continue
         }
         KeyCode::Enter => {
@@ -20,6 +17,10 @@ pub(crate) fn handle_quit_confirm(key: KeyEvent, state: &mut AppState) -> InputO
                 state.quit_confirm_visible = false;
                 InputOutcome::Continue
             }
+        }
+        _ if toggles_binary_choice(&key, &state.keymap) => {
+            state.quit_confirm_selected = if state.quit_confirm_selected == 0 { 1 } else { 0 };
+            InputOutcome::Continue
         }
         _ => InputOutcome::Continue,
     }


### PR DESCRIPTION
## Summary
- `handle_confirm_input` only toggled Yes/No on hardcoded `KeyCode::Left`/`Right`/`Up`/`Down`, ignoring whatever the user has bound to `Action::SubTabLeft`/`SubTabRight` (default `h`/`l`, configurable via the in-app key editor) — the one place in the app where movement didn't follow the keymap.
- Now also checks `state.keymap.action(&key)` for those two actions; arrow keys still work unconditionally as a fallback.
- Pulled the toggle condition into a small pure `toggles_confirm_selection` helper so it's unit-testable without spinning up a full `AppData` (no existing precedent for that in this module).

Fixes #39.

## Test plan
- [x] `cargo test` (38 passed, incl. 2 new: default h/l toggle + a rebound left/right still works)
- [x] `cargo check`
- [ ] Manual: trigger a confirm popup (e.g. delete a playlist), press `h`/`l` — should flip Yes/No same as arrow keys