### PR TITLE
Coalesce spammed Play commands to the last one landed on

### DIFF
--- a/src/player/worker.rs
+++ b/src/player/worker.rs
@@ -12,6 +12,32 @@ use super::Position;
 use super::commands::PlayerCommand;
 use super::stream::{PlaybackEngine, open_output_stream};
 
+/// Pulls the next command to act on. Spam-skipping next/prev queues a burst of `Play`
+/// commands faster than one can load, so a run of them already waiting in the channel is
+/// collapsed down to the last one — only the track the user actually lands on should be
+/// loaded/started. A non-`Play` command pulled ahead while coalescing is handed back via
+/// `pending` and returned first on the next call, so nothing skips ahead of it out of order.
+fn next_command(rx: &Receiver<PlayerCommand>, pending: &mut Option<PlayerCommand>) -> Option<PlayerCommand> {
+    let msg = match pending.take() {
+        Some(msg) => msg,
+        None => rx.recv().ok()?,
+    };
+    Some(if matches!(msg, PlayerCommand::Play(_)) {
+        let mut latest = msg;
+        while let Ok(next) = rx.try_recv() {
+            if matches!(next, PlayerCommand::Play(_)) {
+                latest = next;
+            } else {
+                *pending = Some(next);
+                break;
+            }
+        }
+        latest
+    } else {
+        msg
+    })
+}
+
 pub(crate) fn player_loop(
     rx: Receiver<PlayerCommand>,
     token: Arc<Mutex<Token>>,
@@ -24,7 +50,8 @@ pub(crate) fn player_loop(
     let stream = open_output_stream();
     let mut engine = PlaybackEngine::new(Arc::clone(&stream)).unwrap();
 
-    for msg in rx {
+    let mut pending: Option<PlayerCommand> = None;
+    while let Some(msg) = next_command(&rx, &mut pending) {
         match msg {
             PlayerCommand::Play(track) => {
                 engine.play_from_position(
@@ -163,5 +190,83 @@ pub(crate) fn player_loop(
                 is_seeking_flag.store(false, Ordering::SeqCst);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::Track;
+    use std::sync::mpsc;
+
+    fn track(urn: &str) -> Track {
+        Track {
+            title: String::new(),
+            artists: String::new(),
+            duration: String::new(),
+            duration_ms: 0,
+            playback_count: String::new(),
+            artwork_url: String::new(),
+            access: String::new(),
+            track_urn: urn.into(),
+        }
+    }
+
+    fn urn(cmd: &PlayerCommand) -> &str {
+        match cmd {
+            PlayerCommand::Play(t) => &t.track_urn,
+            _ => panic!("expected Play"),
+        }
+    }
+
+    #[test]
+    fn a_burst_of_plays_collapses_to_the_last_one() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(PlayerCommand::Play(track("a"))).unwrap();
+        tx.send(PlayerCommand::Play(track("b"))).unwrap();
+        tx.send(PlayerCommand::Play(track("c"))).unwrap();
+
+        let mut pending = None;
+        let msg = next_command(&rx, &mut pending).unwrap();
+        assert_eq!(urn(&msg), "c");
+        assert!(pending.is_none());
+        assert!(rx.try_recv().is_err(), "the whole burst should be drained");
+    }
+
+    #[test]
+    fn a_non_play_command_after_a_burst_is_returned_next_in_order() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(PlayerCommand::Play(track("a"))).unwrap();
+        tx.send(PlayerCommand::Play(track("b"))).unwrap();
+        tx.send(PlayerCommand::Pause).unwrap();
+        tx.send(PlayerCommand::Play(track("c"))).unwrap();
+
+        let mut pending = None;
+        let first = next_command(&rx, &mut pending).unwrap();
+        assert_eq!(urn(&first), "b", "a and b collapse; pause stops the drain");
+        assert!(matches!(pending, Some(PlayerCommand::Pause)));
+
+        let second = next_command(&rx, &mut pending).unwrap();
+        assert!(matches!(second, PlayerCommand::Pause));
+        assert!(pending.is_none());
+
+        let third = next_command(&rx, &mut pending).unwrap();
+        assert_eq!(urn(&third), "c");
+    }
+
+    #[test]
+    fn single_play_with_nothing_queued_passes_through_unchanged() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(PlayerCommand::Play(track("only"))).unwrap();
+        let mut pending = None;
+        assert_eq!(urn(&next_command(&rx, &mut pending).unwrap()), "only");
+    }
+
+    #[test]
+    fn closed_channel_ends_the_loop() {
+        let (tx, rx) = mpsc::channel::<PlayerCommand>();
+        drop(tx);
+        let mut pending = None;
+        assert!(next_command(&rx, &mut pending).is_none());
     }
 }


### PR DESCRIPTION
## Summary
Went with the issue's second suggested fix (worker drains and discards stale `Play`s) over debouncing on the input side — debouncing would add a fixed delay before *every* single skip starts playing, not just spam-skip bursts, which is a worse regression than the bug it'd fix. Coalescing in the worker keeps the single-skip case exactly as fast as it is now.

- `player_loop` processed every queued `PlayerCommand::Play` in full (a real network fetch + decode start via `engine.play_from_position`) before the next one superseded it, so spam-skipping next/prev briefly loaded every intermediate track along the way.
- New `next_command` helper drains the channel ahead of a `Play`, collapsing any run of further queued `Play`s down to the last one. A non-`Play` command pulled ahead while draining is stashed and returned first on the next call, so relative order is preserved for anything else (Pause, volume, seek, etc).
- Pulled the coalescing logic out into its own function so it's unit-testable independent of the real audio engine/network (nothing else in this module was testable before).

Fixes #41.

## Test plan
- [x] `cargo test` (42 passed, incl. 4 new for `next_command`: burst collapses to last, a non-Play in the middle stops the drain and keeps order, single Play passes through unchanged, closed channel ends the loop)
- [x] `cargo check`
- [ ] Manual: spam next/prev a few times fast — now-playing should jump straight to the settled track instead of flashing through each one in between