### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,7 +3053,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sctui"
-version = "0.1.0"
+version = "0.2.0"
 description = "a soundcloud client for the terminal"
 authors = ["Will Murphy <illogicallledits@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Bumps Cargo.toml/Cargo.lock to 0.2.0 ahead of the v0.2.0 release. release.yml's `check` job requires this to already be on main before the `v0.2.0` tag is pushed (it fails the tag if Cargo.toml doesn't match).

Once merged, push the `v0.2.0` tag to trigger the release pipeline (test -> build all targets -> smoke install -> publish).