### PR TITLE
fix: re-resolve HLS manifest when segment URLs expire mid-track

### DIFF
--- a/src/player/stream/downloader.rs
+++ b/src/player/stream/downloader.rs
@@ -1,3 +1,4 @@
+use reqwest::Url;
 use std::sync::mpsc::Sender;
 use std::sync::{
     Arc, Mutex,
@@ -5,11 +6,18 @@ use std::sync::{
 };
 use std::time::Duration;
 
+use crate::auth::Token;
 use crate::player::Position;
 use crate::player::stream::cache::SegmentCache;
-use crate::player::stream::hls::HlsManifest;
+use crate::player::stream::hls::{HlsManifest, resolve_manifest};
 
 pub(crate) const PREFETCH_SEGMENTS: usize = 3;
+const RETRY_DELAY: Duration = Duration::from_millis(500);
+/// Failed fetches of one segment before the manifest is assumed stale rather
+/// than the network flaky.
+const ATTEMPTS_BEFORE_REFRESH: usize = 3;
+/// Fresh signed URLs that may still fail before the track is given up on.
+const MAX_REFRESHES: usize = 2;
 
 pub(crate) struct SegmentPumpParams {
     pub client: reqwest::blocking::Client,
@@ -22,6 +30,62 @@ pub(crate) struct SegmentPumpParams {
     pub bytes_tx: Sender<Arc<Vec<u8>>>,
     pub is_playing_flag: Arc<std::sync::atomic::AtomicBool>,
     pub position: Arc<Mutex<Position>>,
+    /// Needed to re-resolve the manifest when its signed URLs expire.
+    pub track_urn: String,
+    pub token: Arc<Mutex<Token>>,
+}
+
+/// Downloads segment `index`, replacing `manifest` with a freshly resolved one
+/// when the URLs in hand stop working.
+///
+/// SoundCloud's segment URLs are signed and expire, and the manifest is fetched
+/// once when the track starts, so anything that leaves the pump idle for long
+/// enough — a long pause, a suspended laptop, a long track — outlives the
+/// signature. A plain retry loop would then hammer a permanently dead URL, so
+/// after `ATTEMPTS_BEFORE_REFRESH` failures the manifest is re-resolved and the
+/// same segment retried against the new URL.
+///
+/// A refresh that itself fails means the network is down rather than the URL
+/// being stale, so it costs nothing from the refresh budget and the loop keeps
+/// waiting — a dropped connection still recovers on its own. Returns `None`
+/// only when there is nothing left to try: cancelled, out of refreshes, or the
+/// track came back re-segmented (which would misalign the cached indices).
+fn fetch_segment(
+    manifest: &mut Arc<HlsManifest>,
+    index: usize,
+    retry_delay: Duration,
+    fetch: &mut impl FnMut(&Url) -> anyhow::Result<Vec<u8>>,
+    refresh: &mut impl FnMut() -> anyhow::Result<HlsManifest>,
+    cancelled: &mut impl FnMut() -> bool,
+) -> Option<Vec<u8>> {
+    let mut failures = 0usize;
+    let mut refreshes = 0usize;
+
+    loop {
+        if cancelled() {
+            return None;
+        }
+        match fetch(&manifest.segments[index].url) {
+            Ok(bytes) => return Some(bytes),
+            Err(_) => failures += 1,
+        }
+
+        if failures >= ATTEMPTS_BEFORE_REFRESH
+            && let Ok(fresh) = refresh()
+        {
+            if fresh.segment_start_ms != manifest.segment_start_ms {
+                return None;
+            }
+            refreshes += 1;
+            if refreshes > MAX_REFRESHES {
+                return None;
+            }
+            *manifest = Arc::new(fresh);
+            failures = 0;
+        }
+
+        std::thread::sleep(retry_delay);
+    }
 }
 
 pub(crate) fn spawn_segment_pump(params: SegmentPumpParams) {
@@ -30,17 +94,21 @@ pub(crate) fn spawn_segment_pump(params: SegmentPumpParams) {
             client,
             generation,
             generation_value,
-            manifest,
+            mut manifest,
             segment_cache,
             start_segment_index,
             bytes_tx,
             is_playing_flag,
             position,
+            track_urn,
+            token,
         } = params;
 
+        let is_cancelled = || generation.load(Ordering::SeqCst) != generation_value;
+
         let mut next_index = start_segment_index.saturating_add(1);
-        'segments: while next_index < manifest.segments.len() {
-            if generation.load(Ordering::SeqCst) != generation_value {
+        while next_index < manifest.segments.len() {
+            if is_cancelled() {
                 break;
             }
 
@@ -69,26 +137,22 @@ pub(crate) fn spawn_segment_pump(params: SegmentPumpParams) {
                     bytes
                 } else {
                     drop(cache_guard);
-                    let url = &manifest.segments[next_index].url;
-                    // A failed fetch is treated as transient (dropped connection, timeout,
-                    // momentary CDN error): wait for the network to come back rather than
-                    // ending the track early. ponytail: retries forever, so a segment whose
-                    // URL is permanently bad (expired signed URL, real 404) stalls the track
-                    // until the user skips; add a max-attempt cap if that shows up in practice.
-                    let bytes = loop {
-                        if generation.load(Ordering::SeqCst) != generation_value {
-                            break 'segments;
-                        }
-                        match client
-                            .get(url.as_str())
-                            .send()
-                            .and_then(|r| r.error_for_status())
-                            .and_then(|r| r.bytes())
-                        {
-                            Ok(b) => break b.to_vec(),
-                            Err(_) => std::thread::sleep(Duration::from_millis(500)),
-                        }
-                    };
+                    let bytes = fetch_segment(
+                        &mut manifest,
+                        next_index,
+                        RETRY_DELAY,
+                        &mut |url| {
+                            Ok(client
+                                .get(url.as_str())
+                                .send()
+                                .and_then(|r| r.error_for_status())
+                                .and_then(|r| r.bytes())?
+                                .to_vec())
+                        },
+                        &mut || resolve_manifest(&client, &track_urn, &token),
+                        &mut || is_cancelled(),
+                    );
+                    let Some(bytes) = bytes else { break };
                     let arc = Arc::new(bytes);
                     let mut cache_guard = segment_cache.lock().unwrap();
                     cache_guard.insert(next_index, Arc::clone(&arc));
@@ -96,7 +160,7 @@ pub(crate) fn spawn_segment_pump(params: SegmentPumpParams) {
                 }
             };
 
-            if generation.load(Ordering::SeqCst) != generation_value {
+            if is_cancelled() {
                 break;
             }
             // Receiver gone means the track was stopped or replaced.
@@ -107,4 +171,142 @@ pub(crate) fn spawn_segment_pump(params: SegmentPumpParams) {
             next_index += 1;
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(tag: &str, segments: usize) -> HlsManifest {
+        HlsManifest {
+            init_url: None,
+            segments: (0..segments)
+                .map(|i| crate::player::stream::hls::HlsSegment {
+                    url: Url::parse(&format!("https://cdn.test/{tag}/{i}?sig={tag}")).unwrap(),
+                })
+                .collect(),
+            segment_start_ms: (0..segments as u64).map(|i| i * 10_000).collect(),
+            total_duration_ms: segments as u64 * 10_000,
+        }
+    }
+
+    /// `fetch` succeeds only for URLs signed by the manifest `refresh` last handed out.
+    fn expiring_fetcher(valid: Arc<Mutex<String>>) -> impl FnMut(&Url) -> anyhow::Result<Vec<u8>> {
+        move |url: &Url| {
+            let sig = valid.lock().unwrap().clone();
+            if url.query() == Some(format!("sig={sig}").as_str()) {
+                Ok(b"segment".to_vec())
+            } else {
+                Err(anyhow::anyhow!("403 expired"))
+            }
+        }
+    }
+
+    #[test]
+    fn expired_urls_are_refreshed_and_the_same_segment_still_arrives() {
+        let mut m = Arc::new(manifest("stale", 4));
+        let valid = Arc::new(Mutex::new("fresh".to_string()));
+        let mut refreshes = 0;
+
+        let bytes = fetch_segment(
+            &mut m,
+            2,
+            Duration::ZERO,
+            &mut expiring_fetcher(Arc::clone(&valid)),
+            &mut || {
+                refreshes += 1;
+                Ok(manifest("fresh", 4))
+            },
+            &mut || false,
+        );
+
+        assert_eq!(bytes.as_deref(), Some(&b"segment"[..]));
+        assert_eq!(refreshes, 1, "one refresh should be enough");
+        assert_eq!(m.segments[2].url.query(), Some("sig=fresh"));
+    }
+
+    #[test]
+    fn a_permanently_dead_segment_gives_up_instead_of_retrying_forever() {
+        let mut m = Arc::new(manifest("stale", 4));
+        let mut refreshes = 0;
+
+        let bytes = fetch_segment(
+            &mut m,
+            0,
+            Duration::ZERO,
+            &mut |_| Err(anyhow::anyhow!("404")),
+            &mut || {
+                refreshes += 1;
+                Ok(manifest("fresh", 4))
+            },
+            &mut || false,
+        );
+
+        assert!(bytes.is_none());
+        assert_eq!(refreshes, MAX_REFRESHES + 1);
+    }
+
+    #[test]
+    fn a_refresh_that_fails_is_free_so_a_network_outage_still_recovers() {
+        let mut m = Arc::new(manifest("stale", 4));
+        let valid = Arc::new(Mutex::new("nothing-works-yet".to_string()));
+        let mut fetch = expiring_fetcher(Arc::clone(&valid));
+        // Offline for a while: every fetch and every refresh fails. Then the
+        // network returns and the original URLs turn out to be fine after all.
+        let refresh_attempts = std::cell::Cell::new(0);
+        let bytes = fetch_segment(
+            &mut m,
+            1,
+            Duration::ZERO,
+            &mut |url| {
+                let out = fetch(url);
+                if refresh_attempts.get() >= 5 {
+                    *valid.lock().unwrap() = "stale".to_string();
+                }
+                out
+            },
+            &mut || {
+                refresh_attempts.set(refresh_attempts.get() + 1);
+                Err(anyhow::anyhow!("dns failure"))
+            },
+            &mut || false,
+        );
+
+        assert_eq!(bytes.as_deref(), Some(&b"segment"[..]));
+        assert!(refresh_attempts.get() >= 5, "kept waiting rather than giving up");
+        assert_eq!(m.segments[1].url.query(), Some("sig=stale"), "manifest untouched");
+    }
+
+    #[test]
+    fn a_re_segmented_track_is_given_up_on_rather_than_stitched_wrongly() {
+        let mut m = Arc::new(manifest("stale", 4));
+        let bytes = fetch_segment(
+            &mut m,
+            0,
+            Duration::ZERO,
+            &mut |_| Err(anyhow::anyhow!("403 expired")),
+            &mut || Ok(manifest("fresh", 7)),
+            &mut || false,
+        );
+        assert!(bytes.is_none());
+        assert_eq!(m.segments.len(), 4, "cached segment indices stay as they were");
+    }
+
+    #[test]
+    fn cancellation_stops_the_retry_loop() {
+        let mut m = Arc::new(manifest("stale", 4));
+        let mut ticks = 0;
+        let bytes = fetch_segment(
+            &mut m,
+            0,
+            Duration::ZERO,
+            &mut |_| Err(anyhow::anyhow!("403 expired")),
+            &mut || Ok(manifest("stale", 4)),
+            &mut || {
+                ticks += 1;
+                ticks > 2
+            },
+        );
+        assert!(bytes.is_none());
+    }
 }

--- a/src/player/stream/engine.rs
+++ b/src/player/stream/engine.rs
@@ -9,10 +9,10 @@ use std::time::{Duration, Instant};
 use reqwest::Url;
 
 use crate::api::Track;
-use crate::auth::{Token, try_refresh_token};
+use crate::auth::Token;
 use crate::player::Position;
 use crate::player::stream::cache::{CachedHls, SegmentCache};
-use crate::player::stream::hls::{HlsManifest, StreamsResponse};
+use crate::player::stream::hls::{HlsManifest, resolve_manifest};
 use crate::player::stream::downloader::spawn_segment_pump;
 use crate::player::stream::reader::{PcmSource, SegmentReader};
 use crate::player::stream::sample::TapSource;
@@ -62,28 +62,6 @@ impl PlaybackEngine {
         self.generation.load(Ordering::SeqCst)
     }
 
-    fn get_hls_url(&self, track_urn: &str, access_token: &str) -> anyhow::Result<Url> {
-        let streams_url = format!("https://api.soundcloud.com/tracks/{}/streams", track_urn);
-        let streams_response: StreamsResponse = self
-            .client
-            .get(&streams_url)
-            .bearer_auth(access_token)
-            .send()
-            .context("failed to fetch streams endpoint")?
-            .error_for_status()
-            .context("streams endpoint returned error status")?
-            .json()
-            .context("failed to parse streams response json")?;
-
-        let hls_url = streams_response
-            .hls_aac_160_url
-            .or(streams_response.hls_aac_96_url)
-            .or(streams_response.hls_mp3_128_url)
-            .ok_or_else(|| anyhow::anyhow!("No HLS stream URL available (tried AAC 160, AAC 96, MP3 128)"))?;
-
-        Url::parse(&hls_url).context("invalid HLS URL")
-    }
-
     fn download_bytes(&self, url: &Url) -> anyhow::Result<Vec<u8>> {
         let bytes = self
             .client
@@ -119,11 +97,7 @@ impl PlaybackEngine {
         let cache_valid = self.cache.as_ref().is_some_and(|c| c.is_valid_for(track, now));
 
         if !cache_valid {
-            let _ = try_refresh_token(token);
-            let access_token = { token.lock().unwrap().access_token.clone() };
-
-            let playlist_url = self.get_hls_url(&track.track_urn, &access_token)?;
-            let manifest = HlsManifest::fetch(&self.client, &playlist_url, &access_token)?;
+            let manifest = resolve_manifest(&self.client, &track.track_urn, token)?;
 
             let init_bytes = if let Some(init_url) = &manifest.init_url {
                 Arc::new(self.download_bytes(init_url)?)
@@ -160,11 +134,7 @@ impl PlaybackEngine {
             return Ok(());
         }
 
-        let _ = try_refresh_token(token);
-        let access_token = { token.lock().unwrap().access_token.clone() };
-
-        let playlist_url = self.get_hls_url(&track.track_urn, &access_token)?;
-        let manifest = HlsManifest::fetch(&self.client, &playlist_url, &access_token)?;
+        let manifest = resolve_manifest(&self.client, &track.track_urn, token)?;
 
         let init_bytes = if let Some(init_url) = &manifest.init_url {
             Arc::new(self.download_bytes(init_url)?)
@@ -260,6 +230,9 @@ impl PlaybackEngine {
                         arc
                     }
                     Err(_) => {
+                        // Most likely the cached manifest's signed URLs have expired;
+                        // drop it so the next attempt resolves a fresh one.
+                        self.cache = None;
                         if !is_seek {
                             is_playing_flag.store(false, Ordering::SeqCst);
                             position.lock().unwrap().last_start = None;
@@ -355,6 +328,8 @@ impl PlaybackEngine {
             bytes_tx,
             is_playing_flag: Arc::clone(is_playing_flag),
             position: Arc::clone(position),
+            track_urn: track.track_urn.clone(),
+            token: Arc::clone(token),
         });
     }
 }

--- a/src/player/stream/hls.rs
+++ b/src/player/stream/hls.rs
@@ -2,6 +2,9 @@ use anyhow::Context;
 use m3u8_rs::Playlist;
 use serde::Deserialize;
 use reqwest::Url;
+use std::sync::{Arc, Mutex};
+
+use crate::auth::{Token, try_refresh_token};
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct StreamsResponse {
@@ -14,6 +17,51 @@ pub(crate) struct StreamsResponse {
 #[derive(Debug, Clone)]
 pub(crate) struct HlsSegment {
     pub url: Url,
+}
+
+/// Asks the streams endpoint for this track's playlist URL, preferring the
+/// highest-quality format it offers.
+fn hls_playlist_url(
+    client: &reqwest::blocking::Client,
+    track_urn: &str,
+    access_token: &str,
+) -> anyhow::Result<Url> {
+    let streams_url = format!("https://api.soundcloud.com/tracks/{}/streams", track_urn);
+    let streams_response: StreamsResponse = client
+        .get(&streams_url)
+        .bearer_auth(access_token)
+        .send()
+        .context("failed to fetch streams endpoint")?
+        .error_for_status()
+        .context("streams endpoint returned error status")?
+        .json()
+        .context("failed to parse streams response json")?;
+
+    let hls_url = streams_response
+        .hls_aac_160_url
+        .or(streams_response.hls_aac_96_url)
+        .or(streams_response.hls_mp3_128_url)
+        .ok_or_else(|| {
+            anyhow::anyhow!("No HLS stream URL available (tried AAC 160, AAC 96, MP3 128)")
+        })?;
+
+    Url::parse(&hls_url).context("invalid HLS URL")
+}
+
+/// Resolves a track to a manifest full of ready-to-download segment URLs.
+///
+/// Those URLs are signed and expire, so this is not only how a track starts:
+/// it is also how a track already playing gets fresh ones once the originals
+/// go stale (see `downloader::fetch_segment`).
+pub(crate) fn resolve_manifest(
+    client: &reqwest::blocking::Client,
+    track_urn: &str,
+    token: &Arc<Mutex<Token>>,
+) -> anyhow::Result<HlsManifest> {
+    let _ = try_refresh_token(token);
+    let access_token = { token.lock().unwrap().access_token.clone() };
+    let playlist_url = hls_playlist_url(client, track_urn, &access_token)?;
+    HlsManifest::fetch(client, &playlist_url, &access_token)
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Fixes #50.

## Cause

Confirmed the diagnosis in the issue. `Resume` is a plain `sink.play()` (`src/player/worker.rs:85`) — nothing re-resolves the stream — so the segment pump is the only thing that can recover. It holds one `Arc<HlsManifest>` for the life of the track, prefetches three segments past a play position that is frozen while paused, and its retry loop treated every failure as transient:

```rust
Err(_) => std::thread::sleep(Duration::from_millis(500)),
```

So after a long pause the first segment it wants has an expired signature, it retries the dead URL forever, and `PcmSource::next` keeps handing the sink `Some(0.0)`: silence after the buffered chunk.

## Fix

Option 1 from the issue. Segment fetching moved into `fetch_segment`, which:

- retries a failing segment as before, but after `ATTEMPTS_BEFORE_REFRESH` (3, ~1.5 s) re-resolves the manifest and retries the **same index** against the fresh URLs;
- gives up after `MAX_REFRESHES` (2) fresh manifests still fail — removes the "stalls until the user skips" ceiling the old `ponytail:` comment flagged, which also covers a genuinely dead 404 segment;
- does **not** count a refresh that itself failed against that budget. A failed refresh means the network is down, not that the URL is stale, so the loop keeps waiting and a dropped connection or a sleeping laptop's dead keep-alives still recover on their own, exactly as before;
- refuses a manifest that comes back re-segmented (`segment_start_ms` differs), because the cached segment indices and the bytes already handed to the decoder would no longer line up.

Because the same refresh path runs mid-playback, this also covers a long track outliving its signature while actually playing, not just the paused case.

Two smaller things fell out of it:

- `PlaybackEngine::get_hls_url` + `HlsManifest::fetch` were being paired at three call sites, so they are now one `hls::resolve_manifest(client, track_urn, token)` shared by the engine and the pump. It keeps the `try_refresh_token` call, which matters here: an OAuth token that expired during the same sleep would otherwise break the re-resolve.
- A failed segment download in `play_from_position` now clears `self.cache`, so a seek that hits stale URLs doesn't stay poisoned for the remaining `HLS_CACHE_TTL`.

## Tests

`fetch_segment` takes its fetch/refresh/cancel as closures, so the retry policy is testable without a network. Five cases in `src/player/stream/downloader.rs`: expired URLs refresh and the segment still arrives; a permanently dead segment gives up instead of spinning; a network outage keeps waiting and recovers without spending the refresh budget; a re-segmented track is refused; cancellation breaks the loop.

`cargo test` 47 passed, `cargo clippy --all-targets` clean for the touched files.

## Not done

Manual verification of the original repro (pause a track, sleep the laptop, resume) — I can't drive a real playback session from here, so that's worth a check before merging.