### PR TITLE
feat: accelerate scrolling while a movement key is held

### DIFF
--- a/src/tui/logic/input/mod.rs
+++ b/src/tui/logic/input/mod.rs
@@ -133,8 +133,9 @@ fn has_second_pane(state: &AppState) -> bool {
     }
 }
 
-/// Dispatch one action. Movement handlers still take a `KeyEvent` whose
-/// modifiers select the variant (plain = step, Alt = page, Shift = second pane).
+/// Dispatch one action. Plain Up/Down go through the held-key ramp; the page and
+/// secondary variants still call the movement handlers with a `KeyEvent` whose
+/// modifiers select the variant (Alt = page, Shift = second pane).
 pub(crate) fn run_action(
     action: Action,
     state: &mut AppState,
@@ -156,8 +157,8 @@ pub(crate) fn run_action(
         Action::PrevTab => navigation::handle_tab_switch_back(state),
         Action::SubTabLeft => navigation::sub_tab_left(state, data),
         Action::SubTabRight => navigation::sub_tab_right(state, data),
-        Action::Up => movement::handle_up_key(key(KeyCode::Up, KeyModifiers::NONE), state, data),
-        Action::Down => movement::handle_down_key(key(KeyCode::Down, KeyModifiers::NONE), state, data),
+        Action::Up => movement::handle_step_key(-1, state, data),
+        Action::Down => movement::handle_step_key(1, state, data),
         Action::PageUp => movement::handle_up_key(key(KeyCode::Up, KeyModifiers::ALT), state, data),
         Action::PageDown => movement::handle_down_key(key(KeyCode::Down, KeyModifiers::ALT), state, data),
         // Second pane where there is one; otherwise behave like PageUp/PageDown.

--- a/src/tui/logic/input/mod.rs
+++ b/src/tui/logic/input/mod.rs
@@ -1,9 +1,11 @@
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
+use std::time::Instant;
+
 use crate::keymap::Action;
 use crate::player::Player;
 
-use crate::tui::logic::state::{AppData, AppState};
+use crate::tui::logic::state::{AppData, AppState, Lane};
 
 pub(crate) mod helpers;
 mod quit;
@@ -157,18 +159,34 @@ pub(crate) fn run_action(
         Action::PrevTab => navigation::handle_tab_switch_back(state),
         Action::SubTabLeft => navigation::sub_tab_left(state, data),
         Action::SubTabRight => navigation::sub_tab_right(state, data),
-        Action::Up => movement::handle_step_key(-1, state, data),
-        Action::Down => movement::handle_step_key(1, state, data),
+        Action::Up => movement::handle_step_key(Lane::Primary, -1, KeyModifiers::NONE, state, data),
+        Action::Down => movement::handle_step_key(Lane::Primary, 1, KeyModifiers::NONE, state, data),
         Action::PageUp => movement::handle_up_key(key(KeyCode::Up, KeyModifiers::ALT), state, data),
         Action::PageDown => movement::handle_down_key(key(KeyCode::Down, KeyModifiers::ALT), state, data),
-        // Second pane where there is one; otherwise behave like PageUp/PageDown.
-        Action::SecondaryUp => {
-            let mods = if has_second_pane(state) { KeyModifiers::SHIFT } else { KeyModifiers::ALT };
-            movement::handle_up_key(key(KeyCode::Up, mods), state, data)
+        // Second pane where there is one, and then it ramps like Up/Down; with no second
+        // pane it is a ten-row page jump, which is already a big step and is left alone.
+        Action::SecondaryUp if has_second_pane(state) => {
+            movement::handle_step_key(Lane::Secondary, -1, KeyModifiers::SHIFT, state, data)
         }
+        Action::SecondaryDown if has_second_pane(state) => {
+            movement::handle_step_key(Lane::Secondary, 1, KeyModifiers::SHIFT, state, data)
+        }
+        Action::SecondaryUp => movement::handle_up_key(key(KeyCode::Up, KeyModifiers::ALT), state, data),
         Action::SecondaryDown => {
-            let mods = if has_second_pane(state) { KeyModifiers::SHIFT } else { KeyModifiers::ALT };
-            movement::handle_down_key(key(KeyCode::Down, mods), state, data)
+            movement::handle_down_key(key(KeyCode::Down, KeyModifiers::ALT), state, data)
+        }
+        // The third pane's cursor lives in `run_command`, so the ramp repeats the whole
+        // action rather than a movement handler.
+        Action::TertiaryUp | Action::TertiaryDown => {
+            let dir = if action == Action::TertiaryUp { -1 } else { 1 };
+            let mut outcome = InputOutcome::Continue;
+            for _ in 0..state.move_accel.step_rows(Lane::Tertiary, dir, Instant::now()) {
+                outcome = commands::run_command(action, state, data, player);
+                if !matches!(outcome, InputOutcome::Continue) {
+                    break;
+                }
+            }
+            outcome
         }
         Action::PlayPause => {
             toggle_play_pause(player);

--- a/src/tui/logic/input/movement.rs
+++ b/src/tui/logic/input/movement.rs
@@ -1,5 +1,6 @@
-use ratatui::crossterm::event::{KeyEvent, KeyModifiers};
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::widgets::TableState;
+use std::time::Instant;
 
 use super::InputOutcome;
 use crate::tui::logic::state::{AppData, AppState, table_rows_count, FollowingTracksFocus};
@@ -36,6 +37,23 @@ fn main_state(subtab: usize, data: &mut AppData) -> &mut TableState {
         3 => &mut data.following_state,
         _ => &mut data.likes_state,
     }
+}
+
+/// Plain Up/Down (`dir` = ±1). Holding the key repeats the single-row step as many times
+/// as the hold ramp asks for, so long lists scroll faster the longer it is held. Repeating
+/// `handle_up_key`/`handle_down_key` rather than scaling the delta keeps every pane's
+/// bounds and focus behaviour identical to a tap.
+pub(crate) fn handle_step_key(dir: isize, state: &mut AppState, data: &mut AppData) -> InputOutcome {
+    let code = if dir < 0 { KeyCode::Up } else { KeyCode::Down };
+    let key = KeyEvent::new(code, KeyModifiers::NONE);
+    for _ in 0..state.move_accel.step_rows(dir, Instant::now()) {
+        if dir < 0 {
+            handle_up_key(key, state, data);
+        } else {
+            handle_down_key(key, state, data);
+        }
+    }
+    InputOutcome::Continue
 }
 
 pub(crate) fn handle_down_key(

--- a/src/tui/logic/input/movement.rs
+++ b/src/tui/logic/input/movement.rs
@@ -3,7 +3,7 @@ use ratatui::widgets::TableState;
 use std::time::Instant;
 
 use super::InputOutcome;
-use crate::tui::logic::state::{AppData, AppState, table_rows_count, FollowingTracksFocus};
+use crate::tui::logic::state::{AppData, AppState, Lane, table_rows_count, FollowingTracksFocus};
 
 /// Single-row move (`delta` = ±1). Moves only if the target row exists (down) or `row > 0` (up);
 /// never clamps a stale row and re-selects only when it actually moved. Returns whether it moved.
@@ -39,14 +39,21 @@ fn main_state(subtab: usize, data: &mut AppData) -> &mut TableState {
     }
 }
 
-/// Plain Up/Down (`dir` = ±1). Holding the key repeats the single-row step as many times
-/// as the hold ramp asks for, so long lists scroll faster the longer it is held. Repeating
-/// `handle_up_key`/`handle_down_key` rather than scaling the delta keeps every pane's
-/// bounds and focus behaviour identical to a tap.
-pub(crate) fn handle_step_key(dir: isize, state: &mut AppState, data: &mut AppData) -> InputOutcome {
+/// A single-row move (`dir` = ±1) on `lane`, where `mods` picks the pane the movement
+/// handlers act on (none = main list, Shift = second pane). Holding the key repeats the
+/// step as many times as the hold ramp asks for, so long lists scroll faster the longer
+/// it is held. Repeating `handle_up_key`/`handle_down_key` rather than scaling the delta
+/// keeps every pane's bounds and focus behaviour identical to a tap.
+pub(crate) fn handle_step_key(
+    lane: Lane,
+    dir: isize,
+    mods: KeyModifiers,
+    state: &mut AppState,
+    data: &mut AppData,
+) -> InputOutcome {
     let code = if dir < 0 { KeyCode::Up } else { KeyCode::Down };
-    let key = KeyEvent::new(code, KeyModifiers::NONE);
-    for _ in 0..state.move_accel.step_rows(dir, Instant::now()) {
+    let key = KeyEvent::new(code, mods);
+    for _ in 0..state.move_accel.step_rows(lane, dir, Instant::now()) {
         if dir < 0 {
             handle_up_key(key, state, data);
         } else {

--- a/src/tui/logic/state.rs
+++ b/src/tui/logic/state.rs
@@ -4,6 +4,7 @@ use crate::keymap::Keymap;
 use crate::theme::{Overrides, Theme};
 use ratatui::widgets::TableState;
 use std::collections::{HashSet, VecDeque};
+use std::time::{Duration, Instant};
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum PlaybackSource {
@@ -308,6 +309,43 @@ impl FetchTask {
     }
 }
 
+/// A movement key still counts as held while its repeats keep arriving this close together;
+/// a longer pause is a tap. Terminal key-repeat rates are ~15-30/s, so this is generous.
+const HOLD_GAP: Duration = Duration::from_millis(150);
+/// Grace period before a hold starts accelerating, so short holds stay one row per repeat.
+const RAMP_DELAY: Duration = Duration::from_millis(300);
+/// How long the ramp from one row to [`MAX_STEP`] takes once it starts.
+const RAMP_SPAN: Duration = Duration::from_millis(1200);
+/// Fastest step, matching the Alt+Up/Down page jump.
+const MAX_STEP: usize = 10;
+
+/// The current run of same-direction movement keypresses, so a held key scrolls
+/// faster the longer it is held.
+#[derive(Default)]
+pub struct MoveAccel {
+    /// Direction, when the run started, and when its last press arrived.
+    run: Option<(isize, Instant, Instant)>,
+}
+
+impl MoveAccel {
+    /// Records a movement press in `dir` at `now` and returns how many rows it should move.
+    /// A pause longer than [`HOLD_GAP`] or a change of direction starts a new run at one row.
+    // ponytail: crossterm events carry no arrival timestamp, so `now` is when the press is
+    // handled, not when it was typed. A frame that stalls for longer than HOLD_GAP therefore
+    // resets the ramp (it falls back to single rows, never overshoots). Upgrade path: stamp
+    // each event with `Instant::now()` in the poll loop and pass that in.
+    pub fn step_rows(&mut self, dir: isize, now: Instant) -> usize {
+        let started = match self.run {
+            Some((d, started, last)) if d == dir && now.duration_since(last) <= HOLD_GAP => started,
+            _ => now,
+        };
+        self.run = Some((dir, started, now));
+        let ramped = now.duration_since(started).saturating_sub(RAMP_DELAY);
+        let progress = (ramped.as_secs_f32() / RAMP_SPAN.as_secs_f32()).min(1.0);
+        1 + ((MAX_STEP - 1) as f32 * progress) as usize
+    }
+}
+
 #[derive(Default)]
 pub struct AppState {
     pub selected_tab: usize,
@@ -403,6 +441,8 @@ pub struct AppState {
     pub search_matches: Vec<usize>,
     pub visualizer_mode: bool,
     pub visualizer_view: VisualizerMode,
+    /// Ramp for held Up/Down, so long lists scroll faster the longer the key is held.
+    pub move_accel: MoveAccel,
     pub end_handled_track_urn: Option<String>,
     pub preload_triggered_for_track_urn: Option<String>,
 }
@@ -555,3 +595,34 @@ pub fn table_rows_count(selected_subtab: usize, data: &AppData) -> usize {
 pub const TAB_TITLES: [&str; 3] = ["Library", "Search", "Feed"];
 pub const SUBTAB_TITLES: [&str; 4] = ["Likes", "Playlists", "Albums", "Following"];
 pub const SEARCHFILTERS: [&str; 4] = ["Tracks", "Albums", "Playlists", "People"];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn held_movement_key_ramps_then_resets() {
+        let mut accel = MoveAccel::default();
+        let t0 = Instant::now();
+        let press = |accel: &mut MoveAccel, dir, ms: u64| {
+            accel.step_rows(dir, t0 + Duration::from_millis(ms))
+        };
+
+        // A tap, and the start of a hold, move a single row.
+        assert_eq!(press(&mut accel, 1, 0), 1);
+        assert_eq!(press(&mut accel, 1, 100), 1);
+
+        // Keep the repeats coming at 50ms: the step ramps up and tops out at MAX_STEP.
+        let rows: Vec<usize> = (150..=1600).step_by(50).map(|ms| press(&mut accel, 1, ms)).collect();
+        assert!(rows.windows(2).all(|w| w[0] <= w[1]), "not monotonic: {rows:?}");
+        assert!(rows.iter().any(|&r| r > 1 && r < MAX_STEP), "no ramp: {rows:?}");
+        assert_eq!(rows.last(), Some(&MAX_STEP));
+
+        // Letting go (a gap longer than HOLD_GAP) drops back to single rows...
+        assert_eq!(press(&mut accel, 1, 1600 + HOLD_GAP.as_millis() as u64 + 1), 1);
+        // ...and so does reversing direction mid-hold.
+        let rows: Vec<usize> = (1800..=3400).step_by(50).map(|ms| press(&mut accel, 1, ms)).collect();
+        assert_eq!(rows.last(), Some(&MAX_STEP));
+        assert_eq!(press(&mut accel, -1, 3450), 1);
+    }
+}

--- a/src/tui/logic/state.rs
+++ b/src/tui/logic/state.rs
@@ -313,33 +313,47 @@ impl FetchTask {
 /// a longer pause is a tap. Terminal key-repeat rates are ~15-30/s, so this is generous.
 const HOLD_GAP: Duration = Duration::from_millis(150);
 /// Grace period before a hold starts accelerating, so short holds stay one row per repeat.
-const RAMP_DELAY: Duration = Duration::from_millis(300);
+const RAMP_DELAY: Duration = Duration::from_millis(800);
 /// How long the ramp from one row to [`MAX_STEP`] takes once it starts.
 const RAMP_SPAN: Duration = Duration::from_millis(1200);
 /// Fastest step, matching the Alt+Up/Down page jump.
 const MAX_STEP: usize = 10;
 
+/// Which cursor a held movement key is driving. Each is ramped separately, so
+/// moving to another pane mid-hold starts again at one row.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Lane {
+    Primary,
+    Secondary,
+    Tertiary,
+}
+
 /// The current run of same-direction movement keypresses, so a held key scrolls
 /// faster the longer it is held.
 #[derive(Default)]
 pub struct MoveAccel {
-    /// Direction, when the run started, and when its last press arrived.
-    run: Option<(isize, Instant, Instant)>,
+    /// Lane, direction, when the run started, and when its last press arrived.
+    run: Option<(Lane, isize, Instant, Instant)>,
 }
 
 impl MoveAccel {
-    /// Records a movement press in `dir` at `now` and returns how many rows it should move.
-    /// A pause longer than [`HOLD_GAP`] or a change of direction starts a new run at one row.
+    /// Records a movement press on `lane` in `dir` at `now` and returns how many rows it
+    /// should move. A pause longer than [`HOLD_GAP`], a change of direction, or a change of
+    /// lane starts a new run at one row.
     // ponytail: crossterm events carry no arrival timestamp, so `now` is when the press is
     // handled, not when it was typed. A frame that stalls for longer than HOLD_GAP therefore
     // resets the ramp (it falls back to single rows, never overshoots). Upgrade path: stamp
     // each event with `Instant::now()` in the poll loop and pass that in.
-    pub fn step_rows(&mut self, dir: isize, now: Instant) -> usize {
+    pub fn step_rows(&mut self, lane: Lane, dir: isize, now: Instant) -> usize {
         let started = match self.run {
-            Some((d, started, last)) if d == dir && now.duration_since(last) <= HOLD_GAP => started,
+            Some((l, d, started, last))
+                if l == lane && d == dir && now.duration_since(last) <= HOLD_GAP =>
+            {
+                started
+            }
             _ => now,
         };
-        self.run = Some((dir, started, now));
+        self.run = Some((lane, dir, started, now));
         let ramped = now.duration_since(started).saturating_sub(RAMP_DELAY);
         let progress = (ramped.as_secs_f32() / RAMP_SPAN.as_secs_f32()).min(1.0);
         1 + ((MAX_STEP - 1) as f32 * progress) as usize
@@ -605,24 +619,50 @@ mod tests {
         let mut accel = MoveAccel::default();
         let t0 = Instant::now();
         let press = |accel: &mut MoveAccel, dir, ms: u64| {
-            accel.step_rows(dir, t0 + Duration::from_millis(ms))
+            accel.step_rows(Lane::Primary, dir, t0 + Duration::from_millis(ms))
         };
+        // Full speed is reached RAMP_DELAY + RAMP_SPAN after the run starts.
+        let to_max = (RAMP_DELAY + RAMP_SPAN).as_millis() as u64;
 
         // A tap, and the start of a hold, move a single row.
         assert_eq!(press(&mut accel, 1, 0), 1);
         assert_eq!(press(&mut accel, 1, 100), 1);
 
         // Keep the repeats coming at 50ms: the step ramps up and tops out at MAX_STEP.
-        let rows: Vec<usize> = (150..=1600).step_by(50).map(|ms| press(&mut accel, 1, ms)).collect();
+        let rows: Vec<usize> = (150..=to_max).step_by(50).map(|ms| press(&mut accel, 1, ms)).collect();
         assert!(rows.windows(2).all(|w| w[0] <= w[1]), "not monotonic: {rows:?}");
         assert!(rows.iter().any(|&r| r > 1 && r < MAX_STEP), "no ramp: {rows:?}");
         assert_eq!(rows.last(), Some(&MAX_STEP));
+        // The grace period really is one: a hold shorter than RAMP_DELAY never speeds up.
+        let mut grace = MoveAccel::default();
+        let grace_rows: Vec<usize> = (0..=RAMP_DELAY.as_millis() as u64)
+            .step_by(50)
+            .map(|ms| grace.step_rows(Lane::Primary, 1, t0 + Duration::from_millis(ms)))
+            .collect();
+        assert!(grace_rows.iter().all(|&r| r == 1), "accelerated too early: {grace_rows:?}");
 
         // Letting go (a gap longer than HOLD_GAP) drops back to single rows...
-        assert_eq!(press(&mut accel, 1, 1600 + HOLD_GAP.as_millis() as u64 + 1), 1);
+        let released = to_max + HOLD_GAP.as_millis() as u64 + 1;
+        assert_eq!(press(&mut accel, 1, released), 1);
         // ...and so does reversing direction mid-hold.
-        let rows: Vec<usize> = (1800..=3400).step_by(50).map(|ms| press(&mut accel, 1, ms)).collect();
+        let resumed = released + 50;
+        let rows: Vec<usize> = (resumed..=resumed + to_max)
+            .step_by(50)
+            .map(|ms| press(&mut accel, 1, ms))
+            .collect();
         assert_eq!(rows.last(), Some(&MAX_STEP));
-        assert_eq!(press(&mut accel, -1, 3450), 1);
+        let reversed = resumed + to_max + 50;
+        assert_eq!(press(&mut accel, -1, reversed), 1);
+
+        // A different cursor starts its own run, and coming back starts the first one over.
+        let at = |ms: u64| t0 + Duration::from_millis(ms);
+        let mut lane_ms = reversed;
+        for _ in 0..((to_max / 50) + 2) {
+            accel.step_rows(Lane::Secondary, 1, at(lane_ms));
+            lane_ms += 50;
+        }
+        assert_eq!(accel.step_rows(Lane::Secondary, 1, at(lane_ms)), MAX_STEP);
+        assert_eq!(accel.step_rows(Lane::Tertiary, 1, at(lane_ms + 50)), 1);
+        assert_eq!(accel.step_rows(Lane::Secondary, 1, at(lane_ms + 100)), 1);
     }
 }


### PR DESCRIPTION
Fixes #47.

## Cause

The issue's diagnosis is accurate. The poll loop drains every pending key event per frame (`src/tui/logic/mod.rs:1002-1008`) and hands each Press to `handle_key_event`, which resolves it through the keymap to an `Action`. `Action::Up`/`Action::Down` dispatched straight to `movement::handle_up_key`/`handle_down_key` with no modifiers (`src/tui/logic/input/mod.rs:159-160` before this change), and every plain branch in those handlers ends in `step()` (`src/tui/logic/input/movement.rs:9`), a fixed ±1 move. Nothing anywhere tracked how long a direction had been held, so a held key was exactly as fast as a tapped one.

One correction to the issue text: the ten-row `page()` jump is not only the Alt chord — `Action::PageUp`/`PageDown` and `Action::SecondaryUp`/`SecondaryDown` (when the view has no second pane) also route to it, via synthetic Alt-modified `KeyEvent`s built in `run_action`. Those paths are untouched here.

## Fix

`AppState` gains a `MoveAccel` (`src/tui/logic/state.rs:322-347`) holding the direction, start and last-press time of the current run of movement presses:

- Presses in the same direction arriving within `HOLD_GAP` (150ms) continue the run; anything slower, or a change of direction, starts a new one at a single row.
- After a `RAMP_DELAY` (300ms) grace period, the step grows linearly over `RAMP_SPAN` (1.2s) from 1 row to `MAX_STEP` (10) — the same jump Alt+Up/Down already makes. The four constants sit together at the top of the block as tuning knobs.

`movement::handle_step_key` (`src/tui/logic/input/movement.rs:42`) asks the ramp for a row count and then calls the existing `handle_up_key`/`handle_down_key` that many times, rather than scaling the delta. That keeps every pane's bounds checks and focus side effects (`following_tracks_focus`, `selected_playlist_row`, the search-tab re-`select`) identical to what a burst of taps would do, and needs no signature change in the fourteen per-pane handlers. `run_action` now routes only `Action::Up`/`Action::Down` through it; page and secondary movement are unchanged.

Because the ramp is time-based, an event backlog processed in one frame does not inflate it — the run's elapsed time is real elapsed time, so a burst just replays single-row steps.

## Tests

- `cargo test` — 43 passed, 3 ignored, 0 failed. One new test, `held_movement_key_ramps_then_resets` in `src/tui/logic/state.rs`, drives `step_rows` with synthetic `Instant`s: a tap and the first repeats stay at one row, sustained 50ms repeats ramp monotonically through intermediate sizes and top out at `MAX_STEP`, and both a gap longer than `HOLD_GAP` and a direction reversal drop back to one row. Sanity-checked by mutation: shrinking `HOLD_GAP` to 10ms makes it fail.
- `cargo clippy --quiet --all-targets` — no warnings in the three files touched. The repo's pre-existing warnings elsewhere (and the unrelated `nonminimal_bool` at `state.rs:199`) are untouched; `cargo fmt` was deliberately not run.

## Not done

- Not verified against a real terminal or a running app: there is no SoundCloud session available here, so the ramp constants were reasoned from typical terminal key-repeat rates (~15-30/s), not felt. They are the first thing to tune if the ramp feels too eager or too slow — at 15/s the grace period is about four repeats and full speed arrives after ~1.5s of holding.
- Only plain Up/Down accelerate. The page and secondary/second-pane movements already jump ten rows, and the overlay lists (history, queue, playlist picker, theme picker) handle `Action::Up`/`Down` themselves before the keymap dispatch, so they still step one row per repeat. Extending the ramp to the history popup would be a couple of lines if that is wanted.
- `MoveAccel` times presses as they are *handled*, since crossterm events carry no arrival timestamp. A frame that stalls longer than 150ms mid-hold resets the ramp — it degrades to single-row stepping, never overshoots. Marked with a `ponytail:` comment naming the upgrade path (stamp events in the poll loop).
