### PR TITLE
feat: settings toggles to hide unplayable tracks and the feed tab

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,9 @@
-//! `~/.config/sctui/config.toml`: `[theme]` and `[keys]`. Read once at startup,
-//! rewritten by the in-app key editor and theme picker.
+//! `~/.config/sctui/config.toml`: `[theme]`, `[settings]` and `[keys]`. Read once at
+//! startup, rewritten by the in-app key editor, theme picker and settings page.
 
 use std::path::PathBuf;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::keymap::Keymap;
 use crate::theme::{self, Overrides, Theme};
@@ -16,13 +16,35 @@ pub struct Loaded {
     pub keymap: Keymap,
     pub theme_name: String,
     pub theme_overrides: Overrides,
+    pub settings: Settings,
     pub warnings: Vec<String>,
+}
+
+/// On/off options, edited from the settings page of the `?` overlay.
+#[derive(Deserialize, Serialize, Default, Clone, Copy)]
+#[serde(default)]
+pub struct Settings {
+    pub hide_unplayable: bool,
+    pub hide_feed_tab: bool,
+}
+
+/// One row of the settings page: its label and the field it toggles.
+pub type SettingRow = (&'static str, fn(&mut Settings) -> &mut bool);
+
+impl Settings {
+    /// The settings page, in display order.
+    pub const ROWS: [SettingRow; 2] = [
+        ("Hide unplayable tracks", |s| &mut s.hide_unplayable),
+        ("Hide feed tab", |s| &mut s.hide_feed_tab),
+    ];
 }
 
 #[derive(Deserialize, Default)]
 struct File {
     #[serde(default)]
     theme: ThemeSection,
+    #[serde(default)]
+    settings: Settings,
 }
 
 #[derive(Deserialize, Default)]
@@ -55,12 +77,23 @@ pub fn load() -> Loaded {
     warnings.extend(theme_warnings);
     theme::set(resolved);
 
-    Loaded { keymap, theme_name: base.name.to_string(), theme_overrides: file.theme.colors, warnings }
+    Loaded {
+        keymap,
+        theme_name: base.name.to_string(),
+        theme_overrides: file.theme.colors,
+        settings: file.settings,
+        warnings,
+    }
 }
 
-/// Write the file: theme choice, any colour overrides, and only the key
-/// bindings that differ from the defaults.
-pub fn save(keymap: &Keymap, theme_name: &str, overrides: &Overrides) -> std::io::Result<()> {
+/// Write the file: theme choice, any colour overrides, the settings toggles, and
+/// only the key bindings that differ from the defaults.
+pub fn save(
+    keymap: &Keymap,
+    theme_name: &str,
+    overrides: &Overrides,
+    settings: &Settings,
+) -> std::io::Result<()> {
     let path = path();
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)?;
@@ -75,6 +108,8 @@ pub fn save(keymap: &Keymap, theme_name: &str, overrides: &Overrides) -> std::io
             out.push_str(&format!("{role} = \"{value}\"\n"));
         }
     }
+    out.push_str("\n[settings]\n");
+    out.push_str(&settings_section(settings));
     out.push('\n');
     out.push_str(&keymap.keys_section(true));
     std::fs::write(path, out)
@@ -90,8 +125,16 @@ pub fn template() -> String {
     out.push_str(".\n# [theme.colors] overrides single roles with \"#rrggbb\" or a colour name: ");
     out.push_str(&theme::ROLES.join(", "));
     out.push_str(".\n[theme]\nname = \"default\"\n# [theme.colors]\n# accent = \"#7aa2f7\"\n\n");
+    out.push_str("# On/off options, also editable in the app (? then Tab).\n[settings]\n");
+    out.push_str(&settings_section(&Settings::default()));
+    out.push('\n');
     out.push_str(&Keymap::default().keys_section(false));
     out
+}
+
+/// The body of `[settings]`, one `key = bool` per line.
+fn settings_section(settings: &Settings) -> String {
+    toml::to_string(settings).unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -106,6 +149,20 @@ mod tests {
         let file: File = toml::from_str(&text).unwrap();
         assert_eq!(file.theme.name.as_deref(), Some("default"));
         assert!(file.theme.colors.0.is_empty());
+        assert!(!file.settings.hide_unplayable);
+        assert!(!file.settings.hide_feed_tab);
+    }
+
+    #[test]
+    fn settings_round_trip() {
+        let mut settings = Settings::default();
+        for (_, field) in Settings::ROWS {
+            *field(&mut settings) = true;
+        }
+        let text = format!("[settings]\n{}", settings_section(&settings));
+        let file: File = toml::from_str(&text).unwrap();
+        assert!(file.settings.hide_unplayable);
+        assert!(file.settings.hide_feed_tab);
     }
 
     #[test]

--- a/src/tui/logic/filtering.rs
+++ b/src/tui/logic/filtering.rs
@@ -1,6 +1,8 @@
+use ratatui::widgets::TableState;
+
 use crate::api::{Album, Artist, Track};
 
-use super::state::{AppData, AppState};
+use super::state::{AppData, AppState, clamp_row};
 
 pub struct FilteredViews {
     pub likes: Vec<Track>,
@@ -106,5 +108,106 @@ pub fn clamp_selection(
             data.following_state.select(Some(state.selected_row));
         }
         _ => {}
+    }
+}
+
+/// Drop unplayable rows from every loaded list, for the "hide unplayable tracks"
+/// setting. Runs when fetched rows land and when the setting is switched on.
+///
+/// Pages are appended, so pruning a fresh page only shortens the tail: indices
+/// earlier in the list, and any playback queue built from them, are left alone.
+///
+/// ponytail: destructive. Switching the setting back off only refills a list on its
+/// next fetch, so lists that are already fully paged in need a restart. The
+/// alternatives — shadowing every list, or mapping rendered rows back to data
+/// indices in each of the twelve panes — both cost far more than the setting is
+/// worth.
+pub fn prune_unplayable(state: &mut AppState, data: &mut AppData) {
+    let panes: [(&mut Vec<Track>, &mut TableState, &mut usize); 9] = [
+        (&mut data.playlist_tracks, &mut data.playlist_tracks_state, &mut state.selected_playlist_track_row),
+        (&mut data.album_tracks, &mut data.album_tracks_state, &mut state.selected_album_track_row),
+        (&mut data.following_tracks, &mut data.following_tracks_state, &mut state.selected_following_track_row),
+        (&mut data.following_likes_tracks, &mut data.following_likes_state, &mut state.selected_following_like_row),
+        (&mut data.search_playlist_tracks, &mut data.search_playlist_tracks_state, &mut state.search_selected_playlist_track_row),
+        (&mut data.search_album_tracks, &mut data.search_album_tracks_state, &mut state.search_selected_album_track_row),
+        (&mut data.search_people_tracks, &mut data.search_people_tracks_state, &mut state.search_selected_person_track_row),
+        (&mut data.search_people_likes_tracks, &mut data.search_people_likes_state, &mut state.search_selected_person_like_row),
+        (&mut data.feed_tracks, &mut data.feed_tracks_state, &mut state.selected_info_row),
+    ];
+    for (tracks, table, row) in panes {
+        prune_list(tracks, table, row);
+    }
+
+    // Likes, search results and the feed share `selected_row`, so they are pruned with
+    // a scratch cursor and the real one is clamped against whichever list is on screen.
+    let mut scratch = 0;
+    prune_list(&mut data.likes, &mut data.likes_state, &mut scratch);
+    prune_list(&mut data.search_tracks, &mut data.search_tracks_state, &mut scratch);
+    data.feed.retain(|a| a.track.as_ref().is_none_or(Track::is_playable));
+
+    let shown = match (state.selected_tab, state.selected_subtab, state.selected_searchfilter) {
+        (0, 0, _) => Some((data.likes.len(), &mut data.likes_state)),
+        (1, _, 0) => Some((data.search_tracks.len(), &mut data.search_tracks_state)),
+        (2, _, _) => Some((data.feed.len(), &mut data.feed_state)),
+        _ => None,
+    };
+    if let Some((len, table)) = shown {
+        clamp_row(&mut state.selected_row, table, len);
+    }
+}
+
+/// Drop the unplayable tracks from one pane, keeping its cursor in range.
+fn prune_list(tracks: &mut Vec<Track>, table: &mut TableState, row: &mut usize) {
+    if tracks.iter().all(Track::is_playable) {
+        return;
+    }
+    tracks.retain(Track::is_playable);
+    clamp_row(row, table, tracks.len());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn track(urn: &str, access: &str) -> Track {
+        Track {
+            title: urn.to_string(),
+            artists: String::new(),
+            duration: String::new(),
+            duration_ms: 0,
+            playback_count: String::new(),
+            artwork_url: String::new(),
+            access: access.to_string(),
+            track_urn: urn.to_string(),
+        }
+    }
+
+    #[test]
+    fn prune_list_drops_unplayable_and_clamps_the_cursor() {
+        let mut tracks = vec![
+            track("a", "playable"),
+            track("b", "blocked"),
+            track("c", ""),
+            track("d", "preview"),
+        ];
+        let mut table = TableState::default().with_selected(3);
+        let mut row = 3;
+        prune_list(&mut tracks, &mut table, &mut row);
+        assert_eq!(
+            tracks.iter().map(|t| t.track_urn.as_str()).collect::<Vec<_>>(),
+            ["a", "c"]
+        );
+        assert_eq!(row, 1);
+        assert_eq!(table.selected(), Some(1));
+    }
+
+    #[test]
+    fn prune_list_leaves_a_playable_pane_and_its_cursor_alone() {
+        let mut tracks = vec![track("a", "playable"), track("b", "")];
+        let mut table = TableState::default().with_selected(1);
+        let mut row = 1;
+        prune_list(&mut tracks, &mut table, &mut row);
+        assert_eq!(tracks.len(), 2);
+        assert_eq!(row, 1);
     }
 }

--- a/src/tui/logic/filtering.rs
+++ b/src/tui/logic/filtering.rs
@@ -111,19 +111,24 @@ pub fn clamp_selection(
     }
 }
 
-/// Drop unplayable rows from every loaded list, for the "hide unplayable tracks"
-/// setting. Runs when fetched rows land and when the setting is switched on.
+/// Apply the "hide unplayable tracks" setting to every loaded list: take the unplayable
+/// rows out while it is on, and put them back where they were when it is switched off.
+/// Runs when fetched rows land and when the setting is flipped.
 ///
-/// Pages are appended, so pruning a fresh page only shortens the tail: indices
-/// earlier in the list, and any playback queue built from them, are left alone.
+/// Hidden rows are stashed with the index they held in the full list, so restoring is a
+/// sequence of in-order inserts and the original order always comes back. Nothing is
+/// discarded, so the setting is reversible without refetching anything.
 ///
-/// ponytail: destructive. Switching the setting back off only refills a list on its
-/// next fetch, so lists that are already fully paged in need a restart. The
-/// alternatives — shadowing every list, or mapping rendered rows back to data
-/// indices in each of the twelve panes — both cost far more than the setting is
-/// worth.
-pub fn prune_unplayable(state: &mut AppState, data: &mut AppData) {
-    let panes: [(&mut Vec<Track>, &mut TableState, &mut usize); 9] = [
+/// The playback queue indexes `data.playback_tracks`, a snapshot taken when playback
+/// starts, so moving rows around in these lists never disturbs what is playing.
+pub fn apply_unplayable_filter(state: &mut AppState, data: &mut AppData) {
+    let hide = state.settings.hide_unplayable;
+
+    // Likes and the track search share `selected_row` with other panes, so they move with
+    // a scratch cursor and the real one is clamped against whichever list is on screen.
+    let (mut likes_row, mut search_row) = (0usize, 0usize);
+    // The order here indexes `data.hidden_tracks`; keep the two in step.
+    let panes: [(&mut Vec<Track>, &mut TableState, &mut usize); 11] = [
         (&mut data.playlist_tracks, &mut data.playlist_tracks_state, &mut state.selected_playlist_track_row),
         (&mut data.album_tracks, &mut data.album_tracks_state, &mut state.selected_album_track_row),
         (&mut data.following_tracks, &mut data.following_tracks_state, &mut state.selected_following_track_row),
@@ -133,17 +138,29 @@ pub fn prune_unplayable(state: &mut AppState, data: &mut AppData) {
         (&mut data.search_people_tracks, &mut data.search_people_tracks_state, &mut state.search_selected_person_track_row),
         (&mut data.search_people_likes_tracks, &mut data.search_people_likes_state, &mut state.search_selected_person_like_row),
         (&mut data.feed_tracks, &mut data.feed_tracks_state, &mut state.selected_info_row),
+        (&mut data.likes, &mut data.likes_state, &mut likes_row),
+        (&mut data.search_tracks, &mut data.search_tracks_state, &mut search_row),
     ];
-    for (tracks, table, row) in panes {
-        prune_list(tracks, table, row);
+
+    let stashes = &mut data.hidden_tracks;
+    if stashes.len() < panes.len() {
+        stashes.resize_with(panes.len(), Vec::new);
+    }
+    for ((tracks, table, row), stash) in panes.into_iter().zip(stashes.iter_mut()) {
+        if hide {
+            hide_list(tracks, stash, table, row);
+        } else {
+            restore_rows(tracks, stash);
+        }
     }
 
-    // Likes, search results and the feed share `selected_row`, so they are pruned with
-    // a scratch cursor and the real one is clamped against whichever list is on screen.
-    let mut scratch = 0;
-    prune_list(&mut data.likes, &mut data.likes_state, &mut scratch);
-    prune_list(&mut data.search_tracks, &mut data.search_tracks_state, &mut scratch);
-    data.feed.retain(|a| a.track.as_ref().is_none_or(Track::is_playable));
+    if hide {
+        hide_rows(&mut data.feed, &mut data.hidden_feed, |a| {
+            a.track.as_ref().is_none_or(Track::is_playable)
+        });
+    } else {
+        restore_rows(&mut data.feed, &mut data.hidden_feed);
+    }
 
     let shown = match (state.selected_tab, state.selected_subtab, state.selected_searchfilter) {
         (0, 0, _) => Some((data.likes.len(), &mut data.likes_state)),
@@ -156,18 +173,52 @@ pub fn prune_unplayable(state: &mut AppState, data: &mut AppData) {
     }
 }
 
-/// Drop the unplayable tracks from one pane, keeping its cursor in range.
-fn prune_list(tracks: &mut Vec<Track>, table: &mut TableState, row: &mut usize) {
+/// Take the unplayable tracks out of one pane, keeping its cursor in range.
+fn hide_list(
+    tracks: &mut Vec<Track>,
+    stash: &mut Vec<(usize, Track)>,
+    table: &mut TableState,
+    row: &mut usize,
+) {
     if tracks.iter().all(Track::is_playable) {
         return;
     }
-    tracks.retain(Track::is_playable);
+    hide_rows(tracks, stash, Track::is_playable);
     clamp_row(row, table, tracks.len());
+}
+
+/// Move the rows failing `keep` into `stash`, each with the index it holds in the full
+/// list. Pages are only ever appended, so everything already stashed sits before every
+/// row still on screen, which keeps the stash sorted by index.
+fn hide_rows<T: Clone>(rows: &mut Vec<T>, stash: &mut Vec<(usize, T)>, keep: impl Fn(&T) -> bool) {
+    let base = stash.len();
+    let mut index = 0;
+    rows.retain(|row| {
+        let keeping = keep(row);
+        if !keeping {
+            stash.push((base + index, row.clone()));
+        }
+        index += 1;
+        keeping
+    });
+}
+
+/// Put stashed rows back at the indices they came from. Taken in ascending index order
+/// every insert lands correctly, because each earlier row is already back in place.
+fn restore_rows<T>(rows: &mut Vec<T>, stash: &mut Vec<(usize, T)>) {
+    for (index, row) in stash.drain(..) {
+        let at = index.min(rows.len());
+        rows.insert(at, row);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn urns(tracks: &[Track]) -> Vec<&str> {
+        tracks.iter().map(|t| t.track_urn.as_str()).collect()
+    }
 
     fn track(urn: &str, access: &str) -> Track {
         Track {
@@ -183,31 +234,89 @@ mod tests {
     }
 
     #[test]
-    fn prune_list_drops_unplayable_and_clamps_the_cursor() {
+    fn hiding_drops_unplayable_rows_and_clamps_the_cursor() {
         let mut tracks = vec![
             track("a", "playable"),
             track("b", "blocked"),
             track("c", ""),
             track("d", "preview"),
         ];
+        let mut stash = Vec::new();
         let mut table = TableState::default().with_selected(3);
         let mut row = 3;
-        prune_list(&mut tracks, &mut table, &mut row);
-        assert_eq!(
-            tracks.iter().map(|t| t.track_urn.as_str()).collect::<Vec<_>>(),
-            ["a", "c"]
-        );
+        hide_list(&mut tracks, &mut stash, &mut table, &mut row);
+        assert_eq!(urns(&tracks), ["a", "c"]);
         assert_eq!(row, 1);
         assert_eq!(table.selected(), Some(1));
     }
 
     #[test]
-    fn prune_list_leaves_a_playable_pane_and_its_cursor_alone() {
+    fn hiding_leaves_a_playable_pane_and_its_cursor_alone() {
         let mut tracks = vec![track("a", "playable"), track("b", "")];
+        let mut stash = Vec::new();
         let mut table = TableState::default().with_selected(1);
         let mut row = 1;
-        prune_list(&mut tracks, &mut table, &mut row);
+        hide_list(&mut tracks, &mut stash, &mut table, &mut row);
         assert_eq!(tracks.len(), 2);
         assert_eq!(row, 1);
+        assert!(stash.is_empty());
+    }
+
+    #[test]
+    fn restoring_puts_every_hidden_row_back_where_it_was() {
+        let original = vec![
+            track("a", "blocked"),
+            track("b", "playable"),
+            track("c", "preview"),
+            track("d", ""),
+            track("e", "blocked"),
+        ];
+        let mut tracks = original.clone();
+        let mut stash = Vec::new();
+        let (mut table, mut row) = (TableState::default().with_selected(0), 0);
+
+        hide_list(&mut tracks, &mut stash, &mut table, &mut row);
+        assert_eq!(urns(&tracks), ["b", "d"]);
+
+        restore_rows(&mut tracks, &mut stash);
+        assert_eq!(urns(&tracks), urns(&original));
+        assert!(stash.is_empty(), "the stash is emptied by restoring");
+    }
+
+    #[test]
+    fn a_page_appended_while_hidden_still_restores_in_order() {
+        // Hide, let another page land on the shortened list, hide again, then restore:
+        // the result must be the two pages back to back in their original order.
+        let first = vec![track("a", "blocked"), track("b", "playable")];
+        let second = [track("c", "playable"), track("d", "preview")];
+        let mut tracks = first.clone();
+        let mut stash = Vec::new();
+        let (mut table, mut row) = (TableState::default().with_selected(0), 0);
+
+        hide_list(&mut tracks, &mut stash, &mut table, &mut row);
+        tracks.extend(second.iter().cloned());
+        hide_list(&mut tracks, &mut stash, &mut table, &mut row);
+        assert_eq!(urns(&tracks), ["b", "c"]);
+
+        restore_rows(&mut tracks, &mut stash);
+        assert_eq!(urns(&tracks), ["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn hiding_and_restoring_repeatedly_is_stable() {
+        let original = vec![
+            track("a", "preview"),
+            track("b", "playable"),
+            track("c", "blocked"),
+        ];
+        let mut tracks = original.clone();
+        let mut stash = Vec::new();
+        let (mut table, mut row) = (TableState::default().with_selected(0), 0);
+        for _ in 0..3 {
+            hide_list(&mut tracks, &mut stash, &mut table, &mut row);
+            assert_eq!(urns(&tracks), ["b"]);
+            restore_rows(&mut tracks, &mut stash);
+            assert_eq!(urns(&tracks), urns(&original));
+        }
     }
 }

--- a/src/tui/logic/input/commands.rs
+++ b/src/tui/logic/input/commands.rs
@@ -78,6 +78,8 @@ pub(crate) fn run_command(
         Action::Help => {
             state.help_visible = !state.help_visible;
             state.help_selected = 0;
+            state.help_settings = false;
+            state.help_settings_selected = 0;
             state.help_capture = None;
             state.help_message = None;
         }

--- a/src/tui/logic/input/help_editor.rs
+++ b/src/tui/logic/input/help_editor.rs
@@ -1,15 +1,22 @@
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
 use super::InputOutcome;
+use crate::config::Settings;
 use crate::keymap::{Action, Chord};
-use crate::tui::logic::state::AppState;
+use crate::tui::logic::filtering::prune_unplayable;
+use crate::tui::logic::state::{AppData, AppState, visible_tabs};
 
-/// The `?` popup: a modal key editor. Owns every key while open.
-pub(crate) fn handle_help_input(key: KeyEvent, state: &mut AppState) -> InputOutcome {
+/// The `?` popup: a modal key editor, with a settings page behind Tab. Owns every
+/// key while open.
+pub(crate) fn handle_help_input(
+    key: KeyEvent,
+    state: &mut AppState,
+    data: &mut AppData,
+) -> InputOutcome {
     let last = Action::ALL.len() - 1;
     let selected = Action::ALL[state.help_selected.min(last)];
 
-    // Waiting for the key to bind.
+    // Waiting for the key to bind. Tab is a bindable key, so this comes first.
     if let Some(action) = state.help_capture.take() {
         if key.code == KeyCode::Esc {
             state.help_message = Some("Cancelled".to_string());
@@ -21,6 +28,15 @@ pub(crate) fn handle_help_input(key: KeyEvent, state: &mut AppState) -> InputOut
             Err(other) => format!("{} is already bound to {}", chord.label(), other.description()),
         });
         return InputOutcome::Continue;
+    }
+
+    if key.code == KeyCode::Tab {
+        state.help_settings = !state.help_settings;
+        state.help_message = None;
+        return InputOutcome::Continue;
+    }
+    if state.help_settings {
+        return handle_settings_input(key, state, data);
     }
 
     state.help_message = None;
@@ -53,9 +69,55 @@ pub(crate) fn handle_help_input(key: KeyEvent, state: &mut AppState) -> InputOut
     InputOutcome::Continue
 }
 
+/// The settings page: Enter or Space flips the highlighted toggle.
+fn handle_settings_input(key: KeyEvent, state: &mut AppState, data: &mut AppData) -> InputOutcome {
+    let last = Settings::ROWS.len() - 1;
+    state.help_message = None;
+    match (key.code, state.keymap.action(&key)) {
+        (KeyCode::Esc, _) | (_, Some(Action::Help)) => state.help_visible = false,
+        (KeyCode::Enter | KeyCode::Char(' '), _) => {
+            let (label, field) = Settings::ROWS[state.help_settings_selected.min(last)];
+            let value = {
+                let flag = field(&mut state.settings);
+                *flag = !*flag;
+                *flag
+            };
+            apply_settings(state, data);
+            let on = if value { "on" } else { "off" };
+            state.help_message = Some(saved(state, format!("{label}: {on}")));
+        }
+        (_, Some(Action::Up)) | (KeyCode::Up, _) => {
+            state.help_settings_selected = state.help_settings_selected.saturating_sub(1)
+        }
+        (_, Some(Action::Down)) | (KeyCode::Down, _) => {
+            state.help_settings_selected = (state.help_settings_selected + 1).min(last)
+        }
+        (KeyCode::Home, _) => state.help_settings_selected = 0,
+        (KeyCode::End, _) => state.help_settings_selected = last,
+        _ => {}
+    }
+    InputOutcome::Continue
+}
+
+/// Make a just-flipped setting take effect on what is already loaded.
+fn apply_settings(state: &mut AppState, data: &mut AppData) {
+    if state.settings.hide_unplayable {
+        prune_unplayable(state, data);
+    }
+    if state.selected_tab >= visible_tabs(state).len() {
+        state.selected_tab = 0;
+        state.selected_row = 0;
+    }
+}
+
 /// Persist and decorate the message with the outcome.
 fn saved(state: &AppState, msg: String) -> String {
-    match crate::config::save(&state.keymap, &state.theme_name, &state.theme_overrides) {
+    match crate::config::save(
+        &state.keymap,
+        &state.theme_name,
+        &state.theme_overrides,
+        &state.settings,
+    ) {
         Ok(()) => format!("{msg}  · saved"),
         Err(e) => format!("{msg}  · NOT saved: {e}"),
     }

--- a/src/tui/logic/input/help_editor.rs
+++ b/src/tui/logic/input/help_editor.rs
@@ -3,7 +3,7 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use super::InputOutcome;
 use crate::config::Settings;
 use crate::keymap::{Action, Chord};
-use crate::tui::logic::filtering::prune_unplayable;
+use crate::tui::logic::filtering::apply_unplayable_filter;
 use crate::tui::logic::state::{AppData, AppState, visible_tabs};
 
 /// The `?` popup: a modal key editor, with a settings page behind Tab. Owns every
@@ -101,9 +101,7 @@ fn handle_settings_input(key: KeyEvent, state: &mut AppState, data: &mut AppData
 
 /// Make a just-flipped setting take effect on what is already loaded.
 fn apply_settings(state: &mut AppState, data: &mut AppData) {
-    if state.settings.hide_unplayable {
-        prune_unplayable(state, data);
-    }
+    apply_unplayable_filter(state, data);
     if state.selected_tab >= visible_tabs(state).len() {
         state.selected_tab = 0;
         state.selected_row = 0;

--- a/src/tui/logic/input/mod.rs
+++ b/src/tui/logic/input/mod.rs
@@ -59,7 +59,7 @@ pub fn handle_key_event(
         return quit::handle_quit_confirm(key, state);
     }
     if state.help_visible {
-        return help_editor::handle_help_input(key, state);
+        return help_editor::handle_help_input(key, state, data);
     }
     if state.theme_picker_visible {
         return theme_picker::handle_theme_picker_input(key, state);

--- a/src/tui/logic/input/navigation.rs
+++ b/src/tui/logic/input/navigation.rs
@@ -1,17 +1,19 @@
 use super::InputOutcome;
 use super::helpers::reset_search_rows;
 use crate::player::Player;
-use crate::tui::logic::state::{AppData, AppState};
+use crate::tui::logic::state::{AppData, AppState, visible_tabs};
 use crate::tui::logic::utils::{active_tracks, build_queue, build_search_matches};
 
 pub(crate) fn handle_tab_switch(state: &mut AppState) -> InputOutcome {
-    state.selected_tab = (state.selected_tab + 1) % 3;
+    let tabs = visible_tabs(state).len();
+    state.selected_tab = (state.selected_tab + 1) % tabs;
     after_tab_switch(state);
     InputOutcome::Continue
 }
 
 pub(crate) fn handle_tab_switch_back(state: &mut AppState) -> InputOutcome {
-    state.selected_tab = (state.selected_tab + 2) % 3;
+    let tabs = visible_tabs(state).len();
+    state.selected_tab = (state.selected_tab + tabs - 1) % tabs;
     after_tab_switch(state);
     InputOutcome::Continue
 }
@@ -190,4 +192,38 @@ pub(crate) fn handle_prev_track(
             crate::tui::logic::utils::play_queued_track(prev, state, data, player, true);
         }
     InputOutcome::Continue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tabs_in_order(hide_feed_tab: bool) -> Vec<usize> {
+        let mut state = AppState::default();
+        state.settings.hide_feed_tab = hide_feed_tab;
+        let mut seen = vec![state.selected_tab];
+        for _ in 0..3 {
+            handle_tab_switch(&mut state);
+            seen.push(state.selected_tab);
+        }
+        seen
+    }
+
+    #[test]
+    fn tab_cycle_skips_the_feed_when_it_is_hidden() {
+        assert_eq!(tabs_in_order(false), [0, 1, 2, 0]);
+        assert_eq!(tabs_in_order(true), [0, 1, 0, 1]);
+    }
+
+    #[test]
+    fn tab_cycle_back_wraps_to_the_last_visible_tab() {
+        let mut state = AppState::default();
+        handle_tab_switch_back(&mut state);
+        assert_eq!(state.selected_tab, 2);
+
+        let mut state = AppState::default();
+        state.settings.hide_feed_tab = true;
+        handle_tab_switch_back(&mut state);
+        assert_eq!(state.selected_tab, 1);
+    }
 }

--- a/src/tui/logic/input/theme_picker.rs
+++ b/src/tui/logic/input/theme_picker.rs
@@ -30,7 +30,12 @@ pub(crate) fn handle_theme_picker_input(key: KeyEvent, state: &mut AppState) -> 
             state.theme_name = chosen.name.to_string();
             state.theme_picker_previous = None;
             state.theme_picker_visible = false;
-            state.help_message = crate::config::save(&state.keymap, &state.theme_name, &state.theme_overrides)
+            state.help_message = crate::config::save(
+                &state.keymap,
+                &state.theme_name,
+                &state.theme_overrides,
+                &state.settings,
+            )
                 .err()
                 .map(|e| format!("theme not saved: {e}"));
         }

--- a/src/tui/logic/mod.rs
+++ b/src/tui/logic/mod.rs
@@ -38,7 +38,7 @@ use reqwest::Method;
 use image::DynamicImage;
 
 use super::render::render;
-use self::filtering::{build_filtered_views, clamp_selection, is_filter_active, prune_unplayable};
+use self::filtering::{apply_unplayable_filter, build_filtered_views, clamp_selection, is_filter_active};
 use self::input::helpers::reset_search_rows;
 use self::input::{InputOutcome, handle_key_event, next_track, prev_track, toggle_play_pause};
 use crate::media::{Media, MediaCommand};
@@ -244,9 +244,7 @@ fn start(
     let mut api_guard = api.lock().unwrap();
     let mut data = AppData::new(&mut api_guard, state.selected_row)?;
     drop(api_guard);
-    if state.settings.hide_unplayable {
-        prune_unplayable(&mut state, &mut data);
-    }
+    apply_unplayable_filter(&mut state, &mut data);
 
     let async_rt = tokio::runtime::Runtime::new().unwrap();
     // Fetch threads hold the `api` lock for whole HTTP requests, so the UI thread must never
@@ -440,8 +438,8 @@ fn start(
                 Msg::Engagement(done) => done.apply(&mut state, &mut data),
             }
         }
-        if fetched && state.settings.hide_unplayable {
-            prune_unplayable(&mut state, &mut data);
+        if fetched {
+            apply_unplayable_filter(&mut state, &mut data);
         }
 
         while let Some(action) = state.engagement_queue.pop_front() {

--- a/src/tui/logic/mod.rs
+++ b/src/tui/logic/mod.rs
@@ -38,7 +38,7 @@ use reqwest::Method;
 use image::DynamicImage;
 
 use super::render::render;
-use self::filtering::{build_filtered_views, clamp_selection, is_filter_active};
+use self::filtering::{build_filtered_views, clamp_selection, is_filter_active, prune_unplayable};
 use self::input::helpers::reset_search_rows;
 use self::input::{InputOutcome, handle_key_event, next_track, prev_track, toggle_play_pause};
 use crate::media::{Media, MediaCommand};
@@ -239,10 +239,14 @@ fn start(
     state.keymap = config.keymap;
     state.theme_name = config.theme_name;
     state.theme_overrides = config.theme_overrides;
+    state.settings = config.settings;
 
     let mut api_guard = api.lock().unwrap();
     let mut data = AppData::new(&mut api_guard, state.selected_row)?;
     drop(api_guard);
+    if state.settings.hide_unplayable {
+        prune_unplayable(&mut state, &mut data);
+    }
 
     let async_rt = tokio::runtime::Runtime::new().unwrap();
     // Fetch threads hold the `api` lock for whole HTTP requests, so the UI thread must never
@@ -256,9 +260,13 @@ fn start(
     spawn_fetch(Arc::clone(api), tx.clone(), |api| {
         api.get_playlists().map(Msg::Playlists)
     });
-    spawn_fetch(Arc::clone(api), tx.clone(), |api| {
-        api.get_activities().map(Msg::Feed)
-    });
+    // Later feed pages are only fetched while the feed tab is on screen, so a hidden
+    // feed tab costs nothing beyond this first page - skip that too.
+    if !state.settings.hide_feed_tab {
+        spawn_fetch(Arc::clone(api), tx.clone(), |api| {
+            api.get_activities().map(Msg::Feed)
+        });
+    }
 
     let mut picker = Picker::from_query_stdio()?;
 
@@ -302,7 +310,11 @@ fn start(
     let mut media_synced_pos: u64 = 0;
 
     loop {
+        // Rows that arrived this iteration; the hide-unplayable setting prunes them
+        // once here rather than in each of the arms below.
+        let mut fetched = false;
         while let Ok(msg) = rx.try_recv() {
+            fetched = true;
             match msg {
                 Msg::Likes(new) => {
                     for t in &new {
@@ -427,6 +439,9 @@ fn start(
                 }
                 Msg::Engagement(done) => done.apply(&mut state, &mut data),
             }
+        }
+        if fetched && state.settings.hide_unplayable {
+            prune_unplayable(&mut state, &mut data);
         }
 
         while let Some(action) = state.engagement_queue.pop_front() {

--- a/src/tui/logic/state.rs
+++ b/src/tui/logic/state.rs
@@ -364,6 +364,7 @@ pub struct AppState {
     pub engagement_queue: VecDeque<Engagement>,
     pub following_tracks_focus: FollowingTracksFocus,
     pub keymap: Keymap,
+    pub settings: crate::config::Settings,
     pub theme_name: String,
     pub theme_overrides: Overrides,
     pub theme_picker_visible: bool,
@@ -375,6 +376,9 @@ pub struct AppState {
     pub lyrics_track_urn: Option<String>,
     /// Key editor (the `?` popup): highlighted action, pending capture, last message.
     pub help_selected: usize,
+    /// The `?` popup's settings page (Tab switches to it) and its highlighted row.
+    pub help_settings: bool,
+    pub help_settings_selected: usize,
     pub help_capture: Option<crate::keymap::Action>,
     pub help_message: Option<String>,
     /// Search tab: printable keys go to the query until Enter/Esc.
@@ -555,3 +559,12 @@ pub fn table_rows_count(selected_subtab: usize, data: &AppData) -> usize {
 pub const TAB_TITLES: [&str; 3] = ["Library", "Search", "Feed"];
 pub const SUBTAB_TITLES: [&str; 4] = ["Likes", "Playlists", "Albums", "Following"];
 pub const SEARCHFILTERS: [&str; 4] = ["Tracks", "Albums", "Playlists", "People"];
+
+/// The tabs the user can reach. Feed is the last one, so hiding it is a shorter slice.
+pub fn visible_tabs(state: &AppState) -> &'static [&'static str] {
+    if state.settings.hide_feed_tab {
+        &TAB_TITLES[..2]
+    } else {
+        &TAB_TITLES
+    }
+}

--- a/src/tui/logic/state.rs
+++ b/src/tui/logic/state.rs
@@ -465,6 +465,12 @@ pub struct AppData {
     pub feed_tracks: Vec<Track>,
     pub feed_tracks_state: TableState,
     pub feed_tracks_key: Option<String>,
+    /// Rows taken out by the "hide unplayable tracks" setting, each with the index it
+    /// held in its full list, so switching the setting back off puts them back where
+    /// they were. One slot per pane, in the order `filtering::apply_unplayable_filter`
+    /// lists them.
+    pub hidden_tracks: Vec<Vec<(usize, Track)>>,
+    pub hidden_feed: Vec<(usize, Activity)>,
 }
 
 impl AppData {
@@ -542,6 +548,8 @@ impl AppData {
             feed_tracks: Vec::new(),
             feed_tracks_state: TableState::default().with_selected(0),
             feed_tracks_key: None,
+            hidden_tracks: Vec::new(),
+            hidden_feed: Vec::new(),
         })
     }
 }

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -19,7 +19,7 @@ use ratatui_image::thread::ThreadProtocol;
 
 use crate::player::Player;
 use crate::tui::logic::filtering::FilteredViews;
-use crate::tui::logic::state::{AppData, AppState, TAB_TITLES};
+use crate::tui::logic::state::{AppData, AppState, visible_tabs};
 use crate::tui::render::visualizer::render_visualizer;
 
 pub fn render(
@@ -60,7 +60,7 @@ pub fn render(
         return;
     }
 
-    render_tabs(frame, chunks[0], &TAB_TITLES, state.selected_tab);
+    render_tabs(frame, chunks[0], visible_tabs(state), state.selected_tab);
 
     if state.selected_tab == 0 {
         tabs::render_library(frame, chunks[1], width, state, data, views);

--- a/src/tui/render/overlays/help.rs
+++ b/src/tui/render/overlays/help.rs
@@ -6,30 +6,41 @@ use ratatui::{
 };
 use crate::theme;
 
+use crate::config::Settings;
 use crate::keymap::Action;
 use crate::tui::logic::state::AppState;
 use crate::tui::render::utils::styled_header;
 
 use super::utils::centered_rect;
 
-/// Key reference and editor, generated from the live keymap.
+/// Key reference and editor, generated from the live keymap. Tab swaps it for the
+/// settings page.
 pub fn render_help(frame: &mut Frame, state: &AppState) {
-    let popup_area = centered_rect(76, 80, frame.area());
-    frame.render_widget(Clear, popup_area);
-
-    let block = Block::default()
-        .title(" Keys ")
-        .title_alignment(Alignment::Center)
-        .borders(Borders::ALL)
-        .border_type(ratatui::widgets::BorderType::Rounded);
-    let inner = block.inner(popup_area);
-    frame.render_widget(block, popup_area);
-    let [table_area, status_area, hint_area] = Layout::vertical([
-        Constraint::Fill(1),
-        Constraint::Length(1),
-        Constraint::Length(1),
-    ])
-    .areas(inner);
+    if state.help_settings {
+        let mut settings = state.settings;
+        let rows: Vec<Row> = Settings::ROWS
+            .iter()
+            .map(|(label, field)| {
+                let on = *field(&mut settings);
+                let row = Row::new(vec![label.to_string(), if on { "on" } else { "off" }.to_string()]);
+                if on {
+                    row
+                } else {
+                    row.style(Style::default().fg(theme::current().dim))
+                }
+            })
+            .collect();
+        render_page(
+            frame,
+            state,
+            " Settings ",
+            &["Setting", "State"],
+            rows,
+            state.help_settings_selected,
+            "Enter/Space: toggle   ↑↓: move   Tab: keys   Esc: close   ·  hidden tracks come back after a restart",
+        );
+        return;
+    }
 
     let rows: Vec<Row> = Action::ALL
         .iter()
@@ -42,9 +53,46 @@ pub fn render_help(frame: &mut Frame, state: &AppState) {
             row
         })
         .collect();
+    render_page(
+        frame,
+        state,
+        " Keys ",
+        &["Action", "Keys"],
+        rows,
+        state.help_selected,
+        "Enter: add key   Backspace: unbind   r: default   ↑↓: move   Tab: settings   Esc: close   ·  saved to ~/.config/sctui/config.toml",
+    );
+}
+
+/// One page of the popup: a two-column table over the shared status and hint lines.
+fn render_page(
+    frame: &mut Frame,
+    state: &AppState,
+    title: &str,
+    header: &[&str],
+    rows: Vec<Row>,
+    selected: usize,
+    hint: &str,
+) {
+    let popup_area = centered_rect(76, 80, frame.area());
+    frame.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .title(title)
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded);
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+    let [table_area, status_area, hint_area] = Layout::vertical([
+        Constraint::Fill(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+    ])
+    .areas(inner);
 
     let table = Table::new(rows, vec![Constraint::Percentage(62), Constraint::Percentage(38)])
-        .header(styled_header(&["Action", "Keys"]))
+        .header(styled_header(header))
         .column_spacing(1)
         .row_highlight_style(
             Style::default()
@@ -52,7 +100,7 @@ pub fn render_help(frame: &mut Frame, state: &AppState) {
                 .fg(theme::current().fg)
                 .add_modifier(Modifier::BOLD),
         );
-    let mut table_state = TableState::default().with_selected(Some(state.help_selected));
+    let mut table_state = TableState::default().with_selected(Some(selected));
     frame.render_stateful_widget(table, table_area, &mut table_state);
 
     let (status, status_style) = match (&state.help_capture, &state.help_message) {
@@ -62,7 +110,7 @@ pub fn render_help(frame: &mut Frame, state: &AppState) {
     };
     frame.render_widget(Paragraph::new(status).style(status_style).alignment(Alignment::Center), status_area);
     frame.render_widget(
-        Paragraph::new("Enter: add key   Backspace: unbind   r: default   ↑↓: move   Esc: close   ·  saved to ~/.config/sctui/config.toml")
+        Paragraph::new(hint)
             .style(Style::default().fg(theme::current().dim))
             .alignment(Alignment::Center),
         hint_area,

--- a/src/tui/render/overlays/help.rs
+++ b/src/tui/render/overlays/help.rs
@@ -37,7 +37,7 @@ pub fn render_help(frame: &mut Frame, state: &AppState) {
             &["Setting", "State"],
             rows,
             state.help_settings_selected,
-            "Enter/Space: toggle   ↑↓: move   Tab: keys   Esc: close   ·  hidden tracks come back after a restart",
+            "Enter/Space: toggle   ↑↓: move   Tab: keys   Esc: close",
         );
         return;
     }


### PR DESCRIPTION
Fixes #38.

Two independent toggles, on a new settings page of the `?` overlay reached with Tab, persisted in a `[settings]` section of `config.toml`.

## Cause

This is a feature request, so there is no bug to diagnose — but the issue's suggestion that hiding unplayable tracks "only changes what's *rendered*" does not survive contact with the code, and the implementation here deliberately differs.

Every list in the app is addressed by position in the `AppData` vectors:

- `src/tui/logic/input/playback.rs:104` plays `tracks(data)[idx]` where `idx` comes straight from a cursor field such as `state.selected_row`.
- `src/tui/logic/utils.rs:239-262` (`build_queue`) stores **indices** into those same vectors, and `src/tui/logic/state.rs:392` (`current_playing_index`) is one too.
- The one place where a rendered list already differs from its data list — the library search filter — has to carry an explicit row→index mapping (`state.search_matches`, `filtering.rs:19` and `input/helpers.rs::filtered_row`), and it only covers 4 of the panes.

So filtering purely at render time would have needed that mapping threaded through all twelve track panes (library likes/playlist/album/following ×2, four search panes, feed tracks) or every Enter, like, queue and playlist action would act on a different track than the highlighted one. Pruning the rows instead keeps every existing index honest.

Two other checks worth recording:

- Queue and history overlays are listed in the issue but need no change: `input/queue.rs` filters `is_playable()` before queueing and `build_queue`/`append_feed_tracks` do the same, so neither can hold an unplayable track. The `is_playable()` styling in `render/overlays/queue.rs:75` is already unreachable.
- Tab navigation was `% 3` against a hardcoded count (`input/navigation.rs:8,14`), and it is the only place `selected_tab` is ever assigned, so making the count the number of *visible* tabs is enough to make the feed unreachable — its render branch (`render/mod.rs:63`), paging (`logic/mod.rs:1179`) and input paths are all already gated on `selected_tab == 2`.

## Fix

- `config.rs`: `Settings { hide_unplayable, hide_feed_tab }`, loaded from `[settings]` and written by the existing `save()` (so the key editor and theme picker keep it in sync). `Settings::ROWS` drives both the UI and the tests. `--dump-config` gains the section.
- `filtering.rs::prune_unplayable`: drops unplayable rows from all twelve track panes plus track posts in the feed, clamping each pane's cursor with the existing `clamp_row`. Called once per loop iteration in which fetched rows landed, once at startup, and once when the toggle is flipped. Pages are appended, so pruning a fresh page only shortens the tail and never shifts an index a live queue holds — the one exception is the flip itself, which is the same index shift `Engagement::UnlikeTrack` already causes today.
- The toggle is destructive, marked with a `ponytail:` comment: switching it back off only refills a list on its next fetch, so a fully paged-in list needs a restart. The settings page hint line says so. The alternative (a shadow copy of every list, or the render-time mapping above) costs far more than the setting is worth.
- `state.rs::visible_tabs` returns the tab titles slice; tab cycling and the tab bar both use it. Flipping `hide_feed_tab` while on the feed tab moves the cursor back to Library, and the feed's first page is no longer fetched at startup when hidden.
- `render/overlays/help.rs`: the popup's block/status/hint scaffolding is factored into `render_page` and shared by the keys and settings pages; both hint lines now mention Tab.

## Tests

- `cargo test`: 47 passed, 0 failed, 3 ignored. New: `filtering::tests::prune_list_drops_unplayable_and_clamps_the_cursor`, `prune_list_leaves_a_playable_pane_and_its_cursor_alone`, `navigation::tests::tab_cycle_skips_the_feed_when_it_is_hidden`, `tab_cycle_back_wraps_to_the_last_visible_tab`, `config::tests::settings_round_trip` (plus the settings assertions added to `template_reloads_as_defaults`).
- `cargo clippy --quiet --all-targets`: no warnings in any file this PR touches. The repo's pre-existing warnings elsewhere (and the `field_reassign_with_default` one already on the `AppState` init block) are untouched.
- `cargo run -- --dump-config` checked by hand: the `[settings]` section is emitted and re-parses.

## Not done

- **No manual run against real playback or the API.** I have no SoundCloud session here, so nothing below the config/logic level was exercised by hand: I have not seen the settings page on a terminal, not watched a list lose its greyed-out rows, and not confirmed the feed tab disappears in a live UI. All of that is reasoned from the code and covered only by the unit tests above.
- Switching `hide_unplayable` off does not bring already-loaded rows back without a restart (see the `ponytail:` comment). Fixing that properly means either a refetch path that resets the API's `Page` cursors or keeping the rows and doing the render-time mapping.
- README not updated; the toggles are discoverable in the app and in `--dump-config`, but if you want them documented alongside the theme and keys sections, say so and I will add it.
- The settings page is a plain two-row list with no grouping or per-row help text beyond the label — enough for two toggles, and `Settings::ROWS` is where a third would go.
