### PR TITLE
feat: 6-band equaliser tab in the '?' menu

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
-//! `~/.config/sctui/config.toml`: `[theme]`, `[settings]` and `[keys]`. Read once at
-//! startup, rewritten by the in-app key editor, theme picker and settings page.
+//! `~/.config/sctui/config.toml`: `[theme]`, `[settings]`, `[eq]` and `[keys]`. Read
+//! once at startup, rewritten by the in-app key editor, theme picker, settings page
+//! and equaliser page.
 
 use std::path::PathBuf;
 
@@ -17,7 +18,30 @@ pub struct Loaded {
     pub theme_name: String,
     pub theme_overrides: Overrides,
     pub settings: Settings,
+    pub eq: Equalizer,
     pub warnings: Vec<String>,
+}
+
+/// Per-band equaliser gains in dB, edited from the EQ page of the `?` overlay.
+/// The length has to match `player::eq::BANDS`; `player::eq::set` won't compile
+/// if it drifts.
+#[derive(Deserialize, Serialize, Default, Clone, Copy)]
+#[serde(default)]
+pub struct Equalizer {
+    pub gains: [i8; 6],
+}
+
+impl Equalizer {
+    /// Pull hand-edited gains back into the range the audio path accepts. Without
+    /// this a `gains = [-100, ...]` in the file would be clamped for playback but
+    /// still drawn (and saved) as -100.
+    fn clamped(mut self) -> Self {
+        let max = crate::player::eq::MAX_GAIN_DB;
+        for gain in &mut self.gains {
+            *gain = (*gain).clamp(-max, max);
+        }
+        self
+    }
 }
 
 /// On/off options, edited from the settings page of the `?` overlay.
@@ -45,6 +69,8 @@ struct File {
     theme: ThemeSection,
     #[serde(default)]
     settings: Settings,
+    #[serde(default)]
+    eq: Equalizer,
 }
 
 #[derive(Deserialize, Default)]
@@ -82,17 +108,19 @@ pub fn load() -> Loaded {
         theme_name: base.name.to_string(),
         theme_overrides: file.theme.colors,
         settings: file.settings,
+        eq: file.eq.clamped(),
         warnings,
     }
 }
 
-/// Write the file: theme choice, any colour overrides, the settings toggles, and
-/// only the key bindings that differ from the defaults.
+/// Write the file: theme choice, any colour overrides, the settings toggles, the
+/// equaliser gains, and only the key bindings that differ from the defaults.
 pub fn save(
     keymap: &Keymap,
     theme_name: &str,
     overrides: &Overrides,
     settings: &Settings,
+    eq: &Equalizer,
 ) -> std::io::Result<()> {
     let path = path();
     if let Some(dir) = path.parent() {
@@ -110,6 +138,8 @@ pub fn save(
     }
     out.push_str("\n[settings]\n");
     out.push_str(&settings_section(settings));
+    out.push_str("\n[eq]\n");
+    out.push_str(&eq_section(eq));
     out.push('\n');
     out.push_str(&keymap.keys_section(true));
     std::fs::write(path, out)
@@ -127,6 +157,9 @@ pub fn template() -> String {
     out.push_str(".\n[theme]\nname = \"default\"\n# [theme.colors]\n# accent = \"#7aa2f7\"\n\n");
     out.push_str("# On/off options, also editable in the app (? then Tab).\n[settings]\n");
     out.push_str(&settings_section(&Settings::default()));
+    out.push_str("\n# Equaliser gains in dB, one per band (60Hz 230Hz 910Hz 3kHz 8kHz 16kHz),\n");
+    out.push_str("# -12 to +12. Also editable in the app (? then Tab twice).\n[eq]\n");
+    out.push_str(&eq_section(&Equalizer::default()));
     out.push('\n');
     out.push_str(&Keymap::default().keys_section(false));
     out
@@ -135,6 +168,11 @@ pub fn template() -> String {
 /// The body of `[settings]`, one `key = bool` per line.
 fn settings_section(settings: &Settings) -> String {
     toml::to_string(settings).unwrap_or_default()
+}
+
+/// The body of `[eq]`, one `gains = [...]` line.
+fn eq_section(eq: &Equalizer) -> String {
+    toml::to_string(eq).unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -151,6 +189,17 @@ mod tests {
         assert!(file.theme.colors.0.is_empty());
         assert!(!file.settings.hide_unplayable);
         assert!(!file.settings.hide_feed_tab);
+        assert_eq!(file.eq.gains, [0; 6]);
+    }
+
+    #[test]
+    fn eq_round_trip() {
+        let eq = Equalizer { gains: [-12, -3, 0, 4, 9, 12] };
+        let file: File = toml::from_str(&format!("[eq]\n{}", eq_section(&eq))).unwrap();
+        assert_eq!(file.eq.gains, eq.gains);
+
+        let wild: File = toml::from_str("[eq]\ngains = [-100, 100, 0, 0, 0, 0]\n").unwrap();
+        assert_eq!(wild.eq.clamped().gains, [-12, 12, 0, 0, 0, 0]);
     }
 
     #[test]

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -4,4 +4,5 @@ mod stream;
 mod worker;
 
 pub use controller::Player;
+pub(crate) use stream::eq;
 pub(crate) use controller::Position;

--- a/src/player/stream/engine.rs
+++ b/src/player/stream/engine.rs
@@ -14,6 +14,7 @@ use crate::player::Position;
 use crate::player::stream::cache::{CachedHls, SegmentCache};
 use crate::player::stream::hls::{HlsManifest, resolve_manifest};
 use crate::player::stream::downloader::spawn_segment_pump;
+use crate::player::stream::eq::EqSource;
 use crate::player::stream::reader::{PcmSource, SegmentReader};
 use crate::player::stream::sample::TapSource;
 
@@ -292,8 +293,9 @@ impl PlaybackEngine {
             Arc::clone(&self.generation),
             gen_for_pump,
         );
+        // EQ inside the tap, so the visualiser draws what is actually heard.
         new_sink.append(TapSource::new(
-            PcmSource::new(pcm_rx, channels, sample_rate),
+            EqSource::new(PcmSource::new(pcm_rx, channels, sample_rate)),
             Arc::clone(wave_buffer),
         ));
 

--- a/src/player/stream/eq.rs
+++ b/src/player/stream/eq.rs
@@ -1,0 +1,307 @@
+//! Six-band peaking equaliser, wrapped around the PCM on its way into the sink.
+//!
+//! The gains live in process globals rather than being threaded down from the
+//! TUI. That is what makes the preview live: the decode thread runs ~1.5 s of
+//! look-ahead, so anything applied before the channel would only be heard a
+//! second and a half after the key press, whereas [`EqSource`] sits after it and
+//! re-reads the gains as the audio callback pulls each sample.
+//!
+//! ponytail: one equaliser per process, which is all a single-sink player needs.
+//! If sctui ever drives two output streams, move these statics onto
+//! `PlaybackEngine` and hand the source an `Arc` to them instead.
+
+use std::sync::atomic::{AtomicI8, AtomicU64, Ordering};
+
+use rodio::Source;
+
+/// Band centre frequencies, in Hz.
+pub(crate) const BANDS: [f32; 6] = [60.0, 230.0, 910.0, 3000.0, 8000.0, 16000.0];
+
+/// How far either side of flat one band can be pushed, in dB.
+pub(crate) const MAX_GAIN_DB: i8 = 12;
+
+/// Bandwidth of each peaking filter. The centres sit one to two octaves apart,
+/// so a Q around 1 leaves neighbouring bands overlapping rather than notched.
+const Q: f32 = 1.0;
+
+static GAINS: [AtomicI8; BANDS.len()] = [const { AtomicI8::new(0) }; BANDS.len()];
+/// Bumped by [`set`]; a live [`EqSource`] recomputes its coefficients when it moves.
+static VERSION: AtomicU64 = AtomicU64::new(0);
+
+/// Install new gains. Takes effect on whatever is already playing.
+pub(crate) fn set(gains: [i8; BANDS.len()]) {
+    for (slot, db) in GAINS.iter().zip(gains) {
+        slot.store(db.clamp(-MAX_GAIN_DB, MAX_GAIN_DB), Ordering::Relaxed);
+    }
+    VERSION.fetch_add(1, Ordering::Release);
+}
+
+/// Human label for a band, e.g. `60 Hz` or `16 kHz`.
+pub(crate) fn band_label(hz: f32) -> String {
+    if hz >= 1000.0 {
+        format!("{} kHz", hz / 1000.0)
+    } else {
+        format!("{hz:.0} Hz")
+    }
+}
+
+/// Signed label for a gain, e.g. `+3 dB`, `-12 dB`, `0 dB`.
+pub(crate) fn gain_label(db: i8) -> String {
+    if db == 0 {
+        "0 dB".to_string()
+    } else {
+        format!("{db:+} dB")
+    }
+}
+
+/// One RBJ-cookbook peaking filter, already normalised by `a0`.
+#[derive(Clone, Copy, Default)]
+struct Biquad {
+    b0: f32,
+    b1: f32,
+    b2: f32,
+    a1: f32,
+    a2: f32,
+    /// False for a flat band (or one above Nyquist), which is then skipped
+    /// entirely so a default EQ is bit-exact passthrough.
+    active: bool,
+}
+
+impl Biquad {
+    fn peaking(freq: f32, sample_rate: f32, gain_db: f32) -> Self {
+        // A band at or above Nyquist has no coefficients worth computing.
+        if gain_db == 0.0 || freq * 2.0 >= sample_rate {
+            return Self::default();
+        }
+        let amp = 10f32.powf(gain_db / 40.0);
+        let w0 = std::f32::consts::TAU * freq / sample_rate;
+        let alpha = w0.sin() / (2.0 * Q);
+        let cos_w0 = w0.cos();
+        let a0 = 1.0 + alpha / amp;
+        Self {
+            b0: (1.0 + alpha * amp) / a0,
+            b1: (-2.0 * cos_w0) / a0,
+            b2: (1.0 - alpha * amp) / a0,
+            a1: (-2.0 * cos_w0) / a0,
+            a2: (1.0 - alpha / amp) / a0,
+            active: true,
+        }
+    }
+}
+
+/// The two-sample history one biquad needs, for one channel.
+#[derive(Clone, Copy, Default)]
+struct BiquadState {
+    x1: f32,
+    x2: f32,
+    y1: f32,
+    y2: f32,
+}
+
+impl BiquadState {
+    fn step(&mut self, c: &Biquad, x: f32) -> f32 {
+        let y = c.b0 * x + c.b1 * self.x1 + c.b2 * self.x2 - c.a1 * self.y1 - c.a2 * self.y2;
+        self.x2 = self.x1;
+        self.x1 = x;
+        self.y2 = self.y1;
+        self.y1 = y;
+        y
+    }
+}
+
+/// Runs the six bands over an interleaved source, one filter chain per channel.
+pub(crate) struct EqSource<S> {
+    inner: S,
+    /// The [`VERSION`] the current coefficients were built from.
+    version: u64,
+    coeffs: [Biquad; BANDS.len()],
+    states: Vec<[BiquadState; BANDS.len()]>,
+    /// Which channel the next sample belongs to; samples arrive interleaved.
+    channel: usize,
+    any_active: bool,
+}
+
+impl<S: Source> EqSource<S> {
+    pub(crate) fn new(inner: S) -> Self {
+        let channels = inner.channels().max(1) as usize;
+        let mut source = Self {
+            inner,
+            version: 0,
+            coeffs: [Biquad::default(); BANDS.len()],
+            states: vec![[BiquadState::default(); BANDS.len()]; channels],
+            channel: 0,
+            any_active: false,
+        };
+        source.reload();
+        source
+    }
+
+    /// Recompute coefficients from the globals, leaving the filter histories
+    /// alone so a mid-track change glides rather than clicks.
+    fn reload(&mut self) {
+        // Version first: reading gains that are newer than it only costs one
+        // redundant reload next sample, whereas the other order could miss a change.
+        self.version = VERSION.load(Ordering::Acquire);
+        let sample_rate = self.inner.sample_rate() as f32;
+        self.coeffs = std::array::from_fn(|i| {
+            Biquad::peaking(BANDS[i], sample_rate, f32::from(GAINS[i].load(Ordering::Relaxed)))
+        });
+        self.any_active = self.coeffs.iter().any(|c| c.active);
+    }
+}
+
+impl<S: Source> Iterator for EqSource<S> {
+    type Item = f32;
+
+    fn next(&mut self) -> Option<f32> {
+        let sample = self.inner.next()?;
+        if self.version != VERSION.load(Ordering::Acquire) {
+            self.reload();
+        }
+        let channel = self.channel;
+        self.channel = (channel + 1) % self.states.len();
+        if !self.any_active {
+            return Some(sample);
+        }
+        let mut out = sample;
+        for (coeff, state) in self.coeffs.iter().zip(self.states[channel].iter_mut()) {
+            if coeff.active {
+                out = state.step(coeff, out);
+            }
+        }
+        // Boosted bands can push past full scale; clip rather than wrap.
+        Some(out.clamp(-1.0, 1.0))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<S: Source> Source for EqSource<S> {
+    fn current_span_len(&self) -> Option<usize> {
+        self.inner.current_span_len()
+    }
+
+    fn channels(&self) -> u16 {
+        self.inner.channels()
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.inner.sample_rate()
+    }
+
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.inner.total_duration()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RATE: u32 = 44_100;
+    /// Well under full scale, so a +12 dB boost has room before the clamp.
+    const AMPLITUDE: f32 = 0.2;
+
+    struct Tone {
+        samples: std::vec::IntoIter<f32>,
+        channels: u16,
+    }
+
+    impl Iterator for Tone {
+        type Item = f32;
+        fn next(&mut self) -> Option<f32> {
+            self.samples.next()
+        }
+    }
+
+    impl Source for Tone {
+        fn current_span_len(&self) -> Option<usize> {
+            None
+        }
+        fn channels(&self) -> u16 {
+            self.channels
+        }
+        fn sample_rate(&self) -> u32 {
+            RATE
+        }
+        fn total_duration(&self) -> Option<std::time::Duration> {
+            None
+        }
+    }
+
+    /// One second of a sine. `right` is the amplitude of the second channel.
+    fn tone(freq: f32, right: Option<f32>) -> Tone {
+        let channels = if right.is_some() { 2 } else { 1 };
+        let samples = (0..RATE as usize)
+            .flat_map(|i| {
+                let phase = (std::f32::consts::TAU * freq * i as f32 / RATE as f32).sin();
+                [Some(AMPLITUDE * phase), right.map(|r| r * phase)]
+            })
+            .flatten()
+            .collect::<Vec<_>>();
+        Tone { samples: samples.into_iter(), channels }
+    }
+
+    /// RMS of the filtered tone, skipping the first 100 ms of filter start-up.
+    fn rms(freq: f32) -> f32 {
+        let out: Vec<f32> = EqSource::new(tone(freq, None)).collect();
+        let tail = &out[RATE as usize / 10..];
+        (tail.iter().map(|s| s * s).sum::<f32>() / tail.len() as f32).sqrt()
+    }
+
+    // One test, because the gains are global and parallel tests would race.
+    #[test]
+    fn bands_boost_their_own_frequency_and_keep_channels_apart() {
+        let flat = AMPLITUDE / 2f32.sqrt();
+
+        set([0; BANDS.len()]);
+        let passthrough: Vec<f32> = EqSource::new(tone(60.0, None)).collect();
+        let untouched: Vec<f32> = tone(60.0, None).collect();
+        assert_eq!(passthrough, untouched, "a flat EQ must not touch the samples");
+
+        // +12 dB on the 60 Hz band is a 10^(12/20) = ~3.98x voltage gain at the centre.
+        set([MAX_GAIN_DB, 0, 0, 0, 0, 0]);
+        let boosted = rms(BANDS[0]);
+        assert!(
+            (boosted / flat - 3.98).abs() < 0.15,
+            "60 Hz should be lifted ~4x, got {boosted} vs flat {flat}"
+        );
+        let distant = rms(BANDS[4]);
+        assert!(
+            (distant / flat - 1.0).abs() < 0.05,
+            "8 kHz should be untouched by the 60 Hz band, got {distant} vs flat {flat}"
+        );
+
+        // A cut is the mirror image.
+        set([-MAX_GAIN_DB, 0, 0, 0, 0, 0]);
+        let cut = rms(BANDS[0]);
+        assert!((cut / flat - 0.251).abs() < 0.05, "60 Hz should be cut ~4x, got {cut}");
+
+        // Silence on the right channel must stay silent: each channel keeps its
+        // own filter history, so nothing bleeds across the interleave.
+        set([MAX_GAIN_DB; BANDS.len()]);
+        let stereo: Vec<f32> = EqSource::new(tone(BANDS[0], Some(0.0))).collect();
+        assert!(
+            stereo.iter().skip(1).step_by(2).all(|s| *s == 0.0),
+            "the silent channel picked up audio from the other one"
+        );
+
+        // Gains outside the range are clamped, not wrapped.
+        set([100; BANDS.len()]);
+        assert!(GAINS.iter().all(|g| g.load(Ordering::Relaxed) == MAX_GAIN_DB));
+        set([0; BANDS.len()]);
+    }
+
+    #[test]
+    fn labels_switch_to_kilohertz() {
+        assert_eq!(band_label(60.0), "60 Hz");
+        assert_eq!(band_label(910.0), "910 Hz");
+        assert_eq!(band_label(3000.0), "3 kHz");
+        assert_eq!(band_label(16000.0), "16 kHz");
+        assert_eq!(gain_label(0), "0 dB");
+        assert_eq!(gain_label(3), "+3 dB");
+        assert_eq!(gain_label(-12), "-12 dB");
+    }
+}

--- a/src/player/stream/mod.rs
+++ b/src/player/stream/mod.rs
@@ -1,4 +1,5 @@
 mod hls;
+pub(crate) mod eq;
 mod cache;
 mod sample;
 mod downloader;

--- a/src/tui/logic/input/commands.rs
+++ b/src/tui/logic/input/commands.rs
@@ -2,7 +2,7 @@ use crate::keymap::Action;
 
 use super::InputOutcome;
 use crate::api::Track;
-use crate::tui::logic::state::{AppData, AppState, ConfirmAction, Engagement, FollowingTracksFocus, PlaybackSource};
+use crate::tui::logic::state::{AppData, AppState, ConfirmAction, Engagement, FollowingTracksFocus, HelpPage, PlaybackSource};
 use crate::player::Player;
 use crate::tui::logic::utils::{active_tracks, build_queue};
 use crate::tui::logic::utils::build_search_matches;
@@ -78,8 +78,9 @@ pub(crate) fn run_command(
         Action::Help => {
             state.help_visible = !state.help_visible;
             state.help_selected = 0;
-            state.help_settings = false;
+            state.help_page = HelpPage::default();
             state.help_settings_selected = 0;
+            state.help_eq_selected = 0;
             state.help_capture = None;
             state.help_message = None;
         }

--- a/src/tui/logic/input/help_editor.rs
+++ b/src/tui/logic/input/help_editor.rs
@@ -102,9 +102,10 @@ fn handle_settings_input(key: KeyEvent, state: &mut AppState, data: &mut AppData
     InputOutcome::Continue
 }
 
-/// The equaliser page: ↑↓ picks a band, ←→ (or h/l) moves it, r flattens it.
-/// Each change goes straight to the audio thread, so it is audible on the track
-/// already playing, and is saved like every other page of the popup.
+/// The equaliser page: ←→ (or h/l) picks a band, ↑↓ (or k/j) moves its fader,
+/// r flattens it. The axes follow the sliders, which are vertical. Each change
+/// goes straight to the audio thread, so it is audible on the track already
+/// playing, and is saved like every other page of the popup.
 fn handle_eq_input(key: KeyEvent, state: &mut AppState) -> InputOutcome {
     let last = eq::BANDS.len() - 1;
     let band = state.help_eq_selected.min(last);
@@ -114,14 +115,14 @@ fn handle_eq_input(key: KeyEvent, state: &mut AppState) -> InputOutcome {
             state.help_visible = false;
             return InputOutcome::Continue;
         }
-        (KeyCode::Left, _) | (_, Some(Action::SubTabLeft)) => -1,
-        (KeyCode::Right, _) | (_, Some(Action::SubTabRight)) => 1,
+        (KeyCode::Up, _) | (_, Some(Action::Up)) => 1,
+        (KeyCode::Down, _) | (_, Some(Action::Down)) => -1,
         (KeyCode::Char('r'), _) => -state.eq.gains[band],
-        (_, Some(Action::Up)) | (KeyCode::Up, _) => {
+        (_, Some(Action::SubTabLeft)) | (KeyCode::Left, _) => {
             state.help_eq_selected = band.saturating_sub(1);
             return InputOutcome::Continue;
         }
-        (_, Some(Action::Down)) | (KeyCode::Down, _) => {
+        (_, Some(Action::SubTabRight)) | (KeyCode::Right, _) => {
             state.help_eq_selected = (band + 1).min(last);
             return InputOutcome::Continue;
         }
@@ -189,6 +190,35 @@ mod tests {
         assert_eq!(page.next(), HelpPage::Settings);
         assert_eq!(page.next().next(), HelpPage::Equalizer);
         assert_eq!(page.next().next().next(), HelpPage::Keys);
+    }
+
+    /// Both axes. Every band is pinned to a rail so no keypress here reaches
+    /// `config::save` or `eq::set`, while the gain keys still prove they are not
+    /// wired to the selection.
+    #[test]
+    fn the_axes_follow_the_vertical_faders() {
+        let press = |code, state: &mut AppState| {
+            handle_eq_input(KeyEvent::from(code), state);
+        };
+        let mut state = AppState {
+            help_page: HelpPage::Equalizer,
+            help_eq_selected: 2,
+            ..Default::default()
+        };
+
+        state.eq.gains = [eq::MAX_GAIN_DB; eq::BANDS.len()];
+        press(KeyCode::Right, &mut state);
+        assert_eq!(state.help_eq_selected, 3, "→ moves to the next band");
+        press(KeyCode::Left, &mut state);
+        assert_eq!(state.help_eq_selected, 2, "← moves to the previous band");
+        press(KeyCode::Up, &mut state);
+        assert_eq!(state.help_eq_selected, 2, "↑ adjusts the gain, it does not move");
+        assert_eq!(state.eq.gains[2], eq::MAX_GAIN_DB, "and stops at the top rail");
+
+        state.eq.gains = [-eq::MAX_GAIN_DB; eq::BANDS.len()];
+        press(KeyCode::Down, &mut state);
+        assert_eq!(state.help_eq_selected, 2, "↓ adjusts the gain, it does not move");
+        assert_eq!(state.eq.gains[2], -eq::MAX_GAIN_DB, "and stops at the bottom rail");
     }
 
     #[test]

--- a/src/tui/logic/input/help_editor.rs
+++ b/src/tui/logic/input/help_editor.rs
@@ -3,11 +3,12 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use super::InputOutcome;
 use crate::config::Settings;
 use crate::keymap::{Action, Chord};
+use crate::player::eq;
 use crate::tui::logic::filtering::apply_unplayable_filter;
-use crate::tui::logic::state::{AppData, AppState, visible_tabs};
+use crate::tui::logic::state::{AppData, AppState, HelpPage, visible_tabs};
 
-/// The `?` popup: a modal key editor, with a settings page behind Tab. Owns every
-/// key while open.
+/// The `?` popup: a modal key editor, with a settings page and an equaliser page
+/// behind Tab. Owns every key while open.
 pub(crate) fn handle_help_input(
     key: KeyEvent,
     state: &mut AppState,
@@ -31,12 +32,14 @@ pub(crate) fn handle_help_input(
     }
 
     if key.code == KeyCode::Tab {
-        state.help_settings = !state.help_settings;
+        state.help_page = state.help_page.next();
         state.help_message = None;
         return InputOutcome::Continue;
     }
-    if state.help_settings {
-        return handle_settings_input(key, state, data);
+    match state.help_page {
+        HelpPage::Settings => return handle_settings_input(key, state, data),
+        HelpPage::Equalizer => return handle_eq_input(key, state),
+        HelpPage::Keys => {}
     }
 
     state.help_message = None;
@@ -99,6 +102,59 @@ fn handle_settings_input(key: KeyEvent, state: &mut AppState, data: &mut AppData
     InputOutcome::Continue
 }
 
+/// The equaliser page: ↑↓ picks a band, ←→ (or h/l) moves it, r flattens it.
+/// Each change goes straight to the audio thread, so it is audible on the track
+/// already playing, and is saved like every other page of the popup.
+fn handle_eq_input(key: KeyEvent, state: &mut AppState) -> InputOutcome {
+    let last = eq::BANDS.len() - 1;
+    let band = state.help_eq_selected.min(last);
+    state.help_message = None;
+    let delta = match (key.code, state.keymap.action(&key)) {
+        (KeyCode::Esc, _) | (_, Some(Action::Help)) => {
+            state.help_visible = false;
+            return InputOutcome::Continue;
+        }
+        (KeyCode::Left, _) | (_, Some(Action::SubTabLeft)) => -1,
+        (KeyCode::Right, _) | (_, Some(Action::SubTabRight)) => 1,
+        (KeyCode::Char('r'), _) => -state.eq.gains[band],
+        (_, Some(Action::Up)) | (KeyCode::Up, _) => {
+            state.help_eq_selected = band.saturating_sub(1);
+            return InputOutcome::Continue;
+        }
+        (_, Some(Action::Down)) | (KeyCode::Down, _) => {
+            state.help_eq_selected = (band + 1).min(last);
+            return InputOutcome::Continue;
+        }
+        (KeyCode::Home, _) => {
+            state.help_eq_selected = 0;
+            return InputOutcome::Continue;
+        }
+        (KeyCode::End, _) => {
+            state.help_eq_selected = last;
+            return InputOutcome::Continue;
+        }
+        _ => return InputOutcome::Continue,
+    };
+    let Some(value) = nudge(&mut state.eq.gains, band, delta) else {
+        return InputOutcome::Continue;
+    };
+    eq::set(state.eq.gains);
+    let label = eq::band_label(eq::BANDS[band]);
+    state.help_message = Some(saved(state, format!("{label}: {}", eq::gain_label(value))));
+    InputOutcome::Continue
+}
+
+/// Move one band, clamped to the equaliser's range. `None` when it was already
+/// at the rail, so holding the key does not keep rewriting the config file.
+fn nudge(gains: &mut [i8; eq::BANDS.len()], band: usize, delta: i8) -> Option<i8> {
+    let current = gains[band];
+    let next = current.saturating_add(delta).clamp(-eq::MAX_GAIN_DB, eq::MAX_GAIN_DB);
+    (next != current).then(|| {
+        gains[band] = next;
+        next
+    })
+}
+
 /// Make a just-flipped setting take effect on what is already loaded.
 fn apply_settings(state: &mut AppState, data: &mut AppData) {
     apply_unplayable_filter(state, data);
@@ -115,8 +171,42 @@ fn saved(state: &AppState, msg: String) -> String {
         &state.theme_name,
         &state.theme_overrides,
         &state.settings,
+        &state.eq,
     ) {
         Ok(()) => format!("{msg}  · saved"),
         Err(e) => format!("{msg}  · NOT saved: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tab_cycles_the_three_pages() {
+        let page = HelpPage::default();
+        assert_eq!(page, HelpPage::Keys);
+        assert_eq!(page.next(), HelpPage::Settings);
+        assert_eq!(page.next().next(), HelpPage::Equalizer);
+        assert_eq!(page.next().next().next(), HelpPage::Keys);
+    }
+
+    #[test]
+    fn a_band_stops_at_the_rails() {
+        let mut gains = [0i8; eq::BANDS.len()];
+        assert_eq!(nudge(&mut gains, 2, 1), Some(1));
+        assert_eq!(gains, [0, 0, 1, 0, 0, 0], "only the selected band moves");
+
+        gains[2] = eq::MAX_GAIN_DB;
+        assert_eq!(nudge(&mut gains, 2, 1), None, "already at the top rail");
+        assert_eq!(gains[2], eq::MAX_GAIN_DB);
+
+        gains[2] = -eq::MAX_GAIN_DB;
+        assert_eq!(nudge(&mut gains, 2, -1), None, "already at the bottom rail");
+
+        // What `r` sends: whatever it takes to get back to flat.
+        gains[2] = -7;
+        assert_eq!(nudge(&mut gains, 2, 7), Some(0));
+        assert_eq!(nudge(&mut gains, 2, 0), None, "flattening a flat band is a no-op");
     }
 }

--- a/src/tui/logic/input/theme_picker.rs
+++ b/src/tui/logic/input/theme_picker.rs
@@ -35,6 +35,7 @@ pub(crate) fn handle_theme_picker_input(key: KeyEvent, state: &mut AppState) -> 
                 &state.theme_name,
                 &state.theme_overrides,
                 &state.settings,
+                &state.eq,
             )
                 .err()
                 .map(|e| format!("theme not saved: {e}"));

--- a/src/tui/logic/mod.rs
+++ b/src/tui/logic/mod.rs
@@ -240,6 +240,8 @@ fn start(
     state.theme_name = config.theme_name;
     state.theme_overrides = config.theme_overrides;
     state.settings = config.settings;
+    state.eq = config.eq;
+    crate::player::eq::set(state.eq.gains);
 
     let mut api_guard = api.lock().unwrap();
     let mut data = AppData::new(&mut api_guard, state.selected_row)?;

--- a/src/tui/logic/state.rs
+++ b/src/tui/logic/state.rs
@@ -360,6 +360,25 @@ impl MoveAccel {
     }
 }
 
+/// Pages of the `?` overlay, in the order Tab walks them.
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum HelpPage {
+    #[default]
+    Keys,
+    Settings,
+    Equalizer,
+}
+
+impl HelpPage {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Keys => Self::Settings,
+            Self::Settings => Self::Equalizer,
+            Self::Equalizer => Self::Keys,
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct AppState {
     pub selected_tab: usize,
@@ -428,9 +447,13 @@ pub struct AppState {
     pub lyrics_track_urn: Option<String>,
     /// Key editor (the `?` popup): highlighted action, pending capture, last message.
     pub help_selected: usize,
-    /// The `?` popup's settings page (Tab switches to it) and its highlighted row.
-    pub help_settings: bool,
+    /// Which page of the `?` popup is showing (Tab cycles), and the highlighted
+    /// row on each of the pages behind the key list.
+    pub help_page: HelpPage,
     pub help_settings_selected: usize,
+    pub help_eq_selected: usize,
+    /// Equaliser gains in dB; `player::eq` holds the copy the audio thread reads.
+    pub eq: crate::config::Equalizer,
     pub help_capture: Option<crate::keymap::Action>,
     pub help_message: Option<String>,
     /// Search tab: printable keys go to the query until Enter/Esc.

--- a/src/tui/render/overlays/help.rs
+++ b/src/tui/render/overlays/help.rs
@@ -1,7 +1,8 @@
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Layout},
+    layout::{Alignment, Constraint, Layout, Rect},
     style::{Modifier, Style},
+    text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Row, Table, TableState},
 };
 use crate::theme;
@@ -12,36 +13,19 @@ use crate::player::eq;
 use crate::tui::logic::state::{AppState, HelpPage};
 use crate::tui::render::utils::styled_header;
 
-use super::utils::centered_rect;
+use super::utils::{centered_rect, centered_rect_fixed};
 
 /// Key reference and editor, generated from the live keymap. Tab cycles it through
 /// the settings and equaliser pages.
 pub fn render_help(frame: &mut Frame, state: &AppState) {
     if state.help_page == HelpPage::Equalizer {
-        let rows: Vec<Row> = eq::BANDS
-            .iter()
-            .zip(state.eq.gains)
-            .map(|(hz, db)| {
-                let row = Row::new(vec![
-                    format!("{:<7}{}", eq::band_label(*hz), slider(db)),
-                    eq::gain_label(db),
-                ]);
-                if db == 0 {
-                    row.style(Style::default().fg(theme::current().dim))
-                } else {
-                    row
-                }
-            })
-            .collect();
-        render_page(
+        let body = render_shell(
             frame,
             state,
             " Equaliser ",
-            &["Band", "Gain"],
-            rows,
-            state.help_eq_selected,
-            "←→: adjust   ↑↓: move   r: flat   Tab: keys   Esc: close",
+            "↑↓: adjust   ←→: band   r: flat   Tab: keys   Esc: close",
         );
+        render_bands(frame, body, state.eq.gains, state.help_eq_selected);
         return;
     }
 
@@ -93,16 +77,104 @@ pub fn render_help(frame: &mut Frame, state: &AppState) {
     );
 }
 
-/// One cell per dB across the full range, with the centre tick marking flat.
-fn slider(db: i8) -> String {
-    let centre = eq::MAX_GAIN_DB as usize;
-    (0..=centre * 2)
-        .map(|i| match i {
-            _ if i == (db + eq::MAX_GAIN_DB) as usize => '█',
-            _ if i == centre => '┼',
-            _ => '─',
-        })
-        .collect()
+/// Widest a band column gets: enough for `230 Hz` and `+12 dB`.
+const WIDE_CELL: u16 = 6;
+/// The fallback when those do not fit: `230` and `+12`.
+const NARROW_CELL: u16 = 3;
+/// Rows either side of the zero line. Past this the faders stop growing with the
+/// popup and stay a graphic EQ rather than a skyscraper.
+const MAX_HALF: usize = 8;
+
+/// Six vertical faders side by side, 0 dB on the shared centre line, fill growing
+/// up for a boost and down for a cut. Centred in whatever space the popup leaves.
+fn render_bands(frame: &mut Frame, area: Rect, gains: [i8; eq::BANDS.len()], selected: usize) {
+    // The zero line plus the two label rows is the smallest thing worth drawing.
+    if area.height < 3 || area.width < NARROW_CELL {
+        return;
+    }
+    let bands = eq::BANDS.len() as u16;
+    let units = area.width >= WIDE_CELL * bands + bands - 1;
+    let (cell, bar) = if units { (WIDE_CELL, 4) } else { (NARROW_CELL, 2) };
+    let width = cell * bands + bands - 1;
+    let half = (((area.height - 3) / 2) as usize).min(MAX_HALF);
+
+    let palette = theme::current();
+    let dim = Style::default().fg(palette.dim);
+    // `faded` is the zero line, which is scenery for every band but the selected one.
+    let style = |band: usize, faded: bool| {
+        if band == selected {
+            // The same highlight the keys and settings tables give their row.
+            Style::default().bg(palette.selection_bg).fg(palette.fg).add_modifier(Modifier::BOLD)
+        } else if faded || gains[band] == 0 {
+            dim
+        } else {
+            Style::default()
+        }
+    };
+    let mut lines: Vec<Line> = Vec::with_capacity(2 * half + 3);
+    let mut push = |gap: char, faded: bool, cell_at: &dyn Fn(usize) -> String| {
+        let mut spans = Vec::with_capacity(2 * eq::BANDS.len());
+        for band in 0..eq::BANDS.len() {
+            if band > 0 {
+                spans.push(Span::styled(gap.to_string(), dim));
+            }
+            spans.push(Span::styled(cell_at(band), style(band, faded)));
+        }
+        lines.push(Line::from(spans));
+    };
+
+    push(' ', false, &|band| format!("{:^1$}", gain_label(gains[band], units), cell as usize));
+    for row in (1..=half).rev() {
+        push(' ', false, &|band| {
+            format!("{:^1$}", fill(gains[band], half, row, true).repeat(bar), cell as usize)
+        });
+    }
+    push('─', true, &|_| "─".repeat(cell as usize));
+    for row in 1..=half {
+        push(' ', false, &|band| {
+            format!("{:^1$}", fill(gains[band], half, row, false).repeat(bar), cell as usize)
+        });
+    }
+    push(' ', false, &|band| format!("{:^1$}", band_label(eq::BANDS[band], units), cell as usize));
+
+    // ponytail: under ~33 columns even the narrow group is wider than the popup
+    // and the paragraph clips it. Showing fewer bands at once would be the fix.
+    let height = lines.len() as u16;
+    frame.render_widget(Paragraph::new(lines), centered_rect_fixed(width, height, area));
+}
+
+/// The character for one cell of a fader, `row` rows above (or below) the zero
+/// line. Half blocks, so a single decibel still shows on a short popup.
+fn fill(db: i8, half: usize, row: usize, above: bool) -> &'static str {
+    if db == 0 || (db > 0) != above {
+        return " ";
+    }
+    let max = eq::MAX_GAIN_DB as usize;
+    let halves = (db.unsigned_abs() as usize * half * 2 + max / 2) / max;
+    match halves.saturating_sub((row - 1) * 2) {
+        0 => " ",
+        1 if above => "▄",
+        1 => "▀",
+        _ => "█",
+    }
+}
+
+/// Band label for one column: `60 Hz` when the column is wide, else `60`.
+fn band_label(hz: f32, units: bool) -> String {
+    match (units, hz >= 1000.0) {
+        (true, _) => eq::band_label(hz),
+        (false, true) => format!("{}k", hz / 1000.0),
+        (false, false) => format!("{hz:.0}"),
+    }
+}
+
+/// Gain label for one column: `+3 dB` when the column is wide, else `+3`.
+fn gain_label(db: i8, units: bool) -> String {
+    match (units, db) {
+        (true, _) => eq::gain_label(db),
+        (false, 0) => "0".to_string(),
+        (false, _) => format!("{db:+}"),
+    }
 }
 
 /// One page of the popup: a two-column table over the shared status and hint lines.
@@ -115,23 +187,7 @@ fn render_page(
     selected: usize,
     hint: &str,
 ) {
-    let popup_area = centered_rect(76, 80, frame.area());
-    frame.render_widget(Clear, popup_area);
-
-    let block = Block::default()
-        .title(title)
-        .title_alignment(Alignment::Center)
-        .borders(Borders::ALL)
-        .border_type(ratatui::widgets::BorderType::Rounded);
-    let inner = block.inner(popup_area);
-    frame.render_widget(block, popup_area);
-    let [table_area, status_area, hint_area] = Layout::vertical([
-        Constraint::Fill(1),
-        Constraint::Length(1),
-        Constraint::Length(1),
-    ])
-    .areas(inner);
-
+    let table_area = render_shell(frame, state, title, hint);
     let table = Table::new(rows, vec![Constraint::Percentage(62), Constraint::Percentage(38)])
         .header(styled_header(header))
         .column_spacing(1)
@@ -143,6 +199,27 @@ fn render_page(
         );
     let mut table_state = TableState::default().with_selected(Some(selected));
     frame.render_stateful_widget(table, table_area, &mut table_state);
+}
+
+/// The popup frame every page shares: border, status line and hint line. Returns
+/// the area left over for the page's own body.
+fn render_shell(frame: &mut Frame, state: &AppState, title: &str, hint: &str) -> Rect {
+    let popup_area = centered_rect(76, 80, frame.area());
+    frame.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .title(title)
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_type(ratatui::widgets::BorderType::Rounded);
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+    let [body_area, status_area, hint_area] = Layout::vertical([
+        Constraint::Fill(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+    ])
+    .areas(inner);
 
     let (status, status_style) = match (&state.help_capture, &state.help_message) {
         (Some(_), Some(msg)) => (msg.clone(), Style::default().fg(theme::current().warning).add_modifier(Modifier::BOLD)),
@@ -156,4 +233,94 @@ fn render_page(
             .alignment(Alignment::Center),
         hint_area,
     );
+    body_area
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    /// The equaliser page as it lands on a terminal of the given size: the glyphs,
+    /// and the columns the selection highlight painted.
+    fn screen(
+        width: u16,
+        height: u16,
+        gains: [i8; eq::BANDS.len()],
+        selected: usize,
+    ) -> (String, Vec<u16>) {
+        let mut state = AppState {
+            help_page: HelpPage::Equalizer,
+            help_eq_selected: selected,
+            ..Default::default()
+        };
+        state.eq.gains = gains;
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| render_help(f, &state)).unwrap();
+        let buf = terminal.backend().buffer();
+        let text = (0..height)
+            .map(|y| (0..width).map(|x| buf[(x, y)].symbol().to_string()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let bg = theme::current().selection_bg;
+        let highlighted = (0..width)
+            .filter(|&x| (0..height).any(|y| buf[(x, y)].bg == bg))
+            .collect();
+        (text, highlighted)
+    }
+
+    /// Column of the middle of `label`'s fader, counted in cells rather than bytes.
+    fn col_of(row: &str, label: &str) -> usize {
+        row[..row.find(label).unwrap()].chars().count() + 2
+    }
+
+    #[test]
+    fn faders_are_vertical_and_centred() {
+        let (s, highlighted) = screen(80, 24, [12, -12, 3, 0, -5, 1], 0);
+        let lines: Vec<&str> = s.lines().collect();
+
+        // Labels top and bottom, zero line between them, and the group centred.
+        let gains = lines.iter().position(|l| l.contains("+12 dB")).unwrap();
+        let inside = |l: &str| l.trim_matches(|c| c == ' ' || c == '│').to_string();
+        let zero = lines
+            .iter()
+            .position(|l| {
+                let l = inside(l);
+                !l.is_empty() && l.chars().all(|c| c == '─')
+            })
+            .unwrap();
+        let bands = lines.iter().position(|l| l.contains("230 Hz")).unwrap();
+        assert!(gains < zero && zero < bands, "{s}");
+        let row = lines[bands];
+        let lead = row.chars().take_while(|c| *c == ' ' || *c == '│').count();
+        let trail = row.chars().rev().take_while(|c| *c == ' ' || *c == '│').count();
+        assert!(lead.abs_diff(trail) <= 1, "band group is not centred:\n{s}");
+
+        // A boost fills above the zero line, a cut below, and flat fills neither.
+        let col = col_of(row, "60 Hz");
+        assert_eq!(lines[zero - 1].chars().nth(col), Some('█'), "+12 dB should fill up:\n{s}");
+        assert_eq!(lines[zero + 1].chars().nth(col), Some(' '), "+12 dB must not fill down:\n{s}");
+        let col = col_of(row, "230 Hz");
+        assert_eq!(lines[zero + 1].chars().nth(col), Some('█'), "-12 dB should fill down:\n{s}");
+        let col = col_of(row, "3 kHz");
+        assert_eq!(lines[zero - 1].chars().nth(col), Some(' '), "0 dB is flat:\n{s}");
+        assert_eq!(lines[zero + 1].chars().nth(col), Some(' '), "0 dB is flat:\n{s}");
+
+        // Only the selected band is highlighted, and only its own column.
+        let start = row[..row.find("60 Hz").unwrap()].chars().count() as u16;
+        assert_eq!(highlighted, (start..start + WIDE_CELL).collect::<Vec<_>>(), "{s}");
+    }
+
+    #[test]
+    fn a_cramped_popup_still_draws_every_band() {
+        // 40x12 leaves three body rows and no room for units on the labels.
+        let (s, highlighted) = screen(40, 12, [12, -12, 3, 0, -5, 1], 3);
+        assert!(s.contains("16k"), "narrow labels missing:\n{s}");
+        assert!(s.contains("-12"), "narrow gains missing:\n{s}");
+        assert_eq!(highlighted.len(), NARROW_CELL as usize, "{s}");
+        // Smaller still: the popup runs out of body entirely, but must not panic.
+        for (w, h) in [(20u16, 6u16), (10, 4), (4, 3), (1, 1)] {
+            screen(w, h, [12, -12, 3, 0, -5, 1], 5);
+        }
+    }
 }

--- a/src/tui/render/overlays/help.rs
+++ b/src/tui/render/overlays/help.rs
@@ -8,15 +8,44 @@ use crate::theme;
 
 use crate::config::Settings;
 use crate::keymap::Action;
-use crate::tui::logic::state::AppState;
+use crate::player::eq;
+use crate::tui::logic::state::{AppState, HelpPage};
 use crate::tui::render::utils::styled_header;
 
 use super::utils::centered_rect;
 
-/// Key reference and editor, generated from the live keymap. Tab swaps it for the
-/// settings page.
+/// Key reference and editor, generated from the live keymap. Tab cycles it through
+/// the settings and equaliser pages.
 pub fn render_help(frame: &mut Frame, state: &AppState) {
-    if state.help_settings {
+    if state.help_page == HelpPage::Equalizer {
+        let rows: Vec<Row> = eq::BANDS
+            .iter()
+            .zip(state.eq.gains)
+            .map(|(hz, db)| {
+                let row = Row::new(vec![
+                    format!("{:<7}{}", eq::band_label(*hz), slider(db)),
+                    eq::gain_label(db),
+                ]);
+                if db == 0 {
+                    row.style(Style::default().fg(theme::current().dim))
+                } else {
+                    row
+                }
+            })
+            .collect();
+        render_page(
+            frame,
+            state,
+            " Equaliser ",
+            &["Band", "Gain"],
+            rows,
+            state.help_eq_selected,
+            "←→: adjust   ↑↓: move   r: flat   Tab: keys   Esc: close",
+        );
+        return;
+    }
+
+    if state.help_page == HelpPage::Settings {
         let mut settings = state.settings;
         let rows: Vec<Row> = Settings::ROWS
             .iter()
@@ -37,7 +66,7 @@ pub fn render_help(frame: &mut Frame, state: &AppState) {
             &["Setting", "State"],
             rows,
             state.help_settings_selected,
-            "Enter/Space: toggle   ↑↓: move   Tab: keys   Esc: close",
+            "Enter/Space: toggle   ↑↓: move   Tab: equaliser   Esc: close",
         );
         return;
     }
@@ -62,6 +91,18 @@ pub fn render_help(frame: &mut Frame, state: &AppState) {
         state.help_selected,
         "Enter: add key   Backspace: unbind   r: default   ↑↓: move   Tab: settings   Esc: close   ·  saved to ~/.config/sctui/config.toml",
     );
+}
+
+/// One cell per dB across the full range, with the centre tick marking flat.
+fn slider(db: i8) -> String {
+    let centre = eq::MAX_GAIN_DB as usize;
+    (0..=centre * 2)
+        .map(|i| match i {
+            _ if i == (db + eq::MAX_GAIN_DB) as usize => '█',
+            _ if i == centre => '┼',
+            _ => '─',
+        })
+        .collect()
 }
 
 /// One page of the popup: a two-column table over the shared status and hint lines.


### PR DESCRIPTION
Fixes #42.

A third page in the `?` overlay: Tab now cycles keys → settings → equaliser.
Six vertical faders, `TestBackend` at 80×24 with the 60 Hz band selected:

```
╭─────────────────────── Equaliser ────────────────────────╮
│        +12 dB -12 dB +3 dB   0 dB  -5 dB  +1 dB          │
│         ████                                             │
│         ████                                             │
│         ████                                             │
│         ████                                             │
│         ████          ▄▄▄▄                               │
│         ████          ████                 ▄▄▄▄          │
│        ─────────────────────────────────────────         │
│                ████                 ████                 │
│                ████                 ████                 │
│                ████                 ▀▀▀▀                 │
│                ████                                      │
│                ████                                      │
│                ████                                      │
│        60 Hz  230 Hz 910 Hz 3 kHz  8 kHz  16 kHz         │
│                                                          │
│                                                          │
│ ↑↓: adjust   ←→: band   r: flat   Tab: keys   Esc: close │
╰──────────────────────────────────────────────────────────╯
```

## Cause

Not a bug, so there is nothing to diagnose — but the issue's implementation
note is only half right, and the half it gets wrong decides the design.

It suggests the EQ "would sit as an additional `Source` wrapper … inserted
before the sink, similar to how `TapSource` already wraps the decoded PCM
source". That is the right place, and it is what this does. What the note does
not mention is *why* the position matters. Decoding does not happen in the sink
chain at all: `spawn_decode_thread` (`src/player/stream/engine.rs:342`) runs the
decoder on its own thread and pushes into a `sync_channel` sized
`PCM_CHUNKS = 64` chunks of `PCM_CHUNK_SAMPLES = 2048`
(`src/player/stream/engine.rs:22-26`), about 1.5 s of stereo 44.1 kHz
look-ahead. Anything applied on the decode side of that channel would only
become audible ~1.5 s after the key press, which fails the issue's "changes
apply to the currently playing track immediately". Only a wrapper on the sink
side of the channel — where `TapSource` already sits, at
`src/player/stream/engine.rs:297` — is pulled by the audio callback and hears a
gain change straight away.

That in turn decides where the gains live. The sink's source is owned by rodio
and pulled from the audio callback, and `PlaybackEngine::play_from_position`
already trips clippy's `too_many_arguments` at 8/7
(`src/player/stream/engine.rs:174`), so threading a handle down from the TUI
through `Player` → `player_loop` → the engine would have meant new arguments on
that path for no benefit. There is exactly one output stream per process
(`open_output_stream`, `src/player/stream/engine.rs:28`), and the codebase
already keeps process-wide UI state this way in `theme::set`/`theme::current`,
so the gains are atomics in the new module with a `ponytail:` note naming the
ceiling.

The UI half of the issue is ambiguous: "each adjustable ±12dB via left/right or
up/down on the selected band" does not say which axis does which, and the layout
decides it. The sliders are vertical, so ←→ (and h/l, via `SubTabLeft`/
`SubTabRight`) move between bands and ↑↓ (and k/j, via `Up`/`Down`) raise and
lower the selected band's gain. Pressing up on a fader pushes the fader up.

**This reverses both axes relative to the first version of this PR**, which drew
the bands as a table of horizontal sliders and so had to spend ↑↓ on picking a
row, leaving ←→ to adjust. That was the right call for horizontal sliders and
the wrong one for vertical ones, so the two swapped when the sliders stood up.
`r` still flattens a band, Home and End still jump to the first and last, Esc
still closes.

## Fix

New `src/player/stream/eq.rs`:

- `EqSource<S>`, a cascade of six RBJ-cookbook peaking biquads, wrapped around
  `PcmSource` *inside* `TapSource` so the visualiser draws what is actually
  heard. Filter state is per channel, indexed off the interleave.
- Gains in `static GAINS: [AtomicI8; 6]` with a `VERSION` counter. `eq::set`
  stores and bumps; the source reloads coefficients when the version moves and
  leaves the filter histories alone, so a mid-track change glides instead of
  clicking.
- A band at 0 dB is skipped entirely, so the default EQ is bit-exact
  passthrough rather than six near-identity filters accumulating float noise. A
  band at or above Nyquist is skipped too, which keeps 16 kHz stable on low
  sample rates.
- Boosts are clamped to ±1.0 on the way out rather than allowed to wrap.

UI and persistence:

- The equaliser page (`src/tui/render/overlays/help.rs`) draws six vertical
  faders as one `Paragraph` of styled `Line`s: the gain in dB above each column,
  the frequency below it, and one zero line running across all six, so a flat EQ
  reads as flat at a glance. Fill grows up from that line for a boost and down
  for a cut, in half-block glyphs (`▄`/`▀`) so a single decibel still shows on a
  short popup. The selected band gets the same `selection_bg` highlight the keys
  and settings tables give their row, over the whole column.
- The group is centred with the overlay's existing `centered_rect_fixed`, so it
  sits in the middle of the popup both ways instead of hugging the top left.
- The page no longer fits `render_page`'s two-column table, so the parts every
  page shares — bordered block, status line, hint line — come out into
  `render_shell`, which returns the area left for the body. `render_page` is that
  shell plus its table; the equaliser page is that shell plus the faders. No new
  layout helpers, no new dependencies.
- `AppState::help_settings: bool` becomes `help_page: HelpPage` (`Keys`,
  `Settings`, `Equalizer`) with a `next()`, so Tab cycles instead of toggling.
  Every reader of the old flag moved with it — `render_help`, `handle_help_input`
  and the `Action::Help` reset in `input/commands.rs`.
- `config::Equalizer { gains: [i8; 6] }` saved as `[eq]` in config.toml, in
  `save()` and in the `--dump-config` template. Both existing `config::save`
  call sites (the help editor and the theme picker) pass it.
- Gains are clamped on load (`Equalizer::clamped`, `src/config.rs:38`), so a
  hand-edited `gains = [-100, …]` cannot leave the page drawing one value while
  the audio path plays another.

## Tests

`cargo test` — 64 passed, 0 failed, 3 ignored (was 56 passed before this
branch; 8 new).

- `player::stream::eq::tests::bands_boost_their_own_frequency_and_keep_channels_apart`
  is the real check on the DSP: it runs a 1 s sine through `EqSource` and asserts
  a flat EQ is bit-identical to the input, that +12 dB on the 60 Hz band lifts a
  60 Hz tone ~3.98× (10^(12/20)) while leaving 8 kHz within 5% of flat, that a
  −12 dB cut is the mirror image, that a silent right channel stays silent with
  all six bands boosted (which is what fails if the interleave indexing breaks),
  and that out-of-range gains clamp. One test rather than several because the
  gains are global and parallel tests would race.
- `tui::render::overlays::help::tests::faders_are_vertical_and_centred` renders
  the page through `TestBackend` at 80×24 and asserts the order gains → zero line
  → frequencies, that the band group's left and right margins match to within a
  cell, that a boost fills above the zero line and only above it, that a cut fills
  below, that a 0 dB band fills neither, and that exactly the selected band's six
  columns carry the highlight.
- `tui::render::overlays::help::tests::a_cramped_popup_still_draws_every_band`
  renders at 40×12, where the popup has three body rows and no room for units, and
  asserts the labels fall back to `16k`/`-12` with all six bands still present and
  still highlightable. It then renders at 20×6, 10×4, 4×3 and 1×1, where the popup
  runs out of body entirely, to pin down that it draws nothing rather than panicking
  or overflowing.
- `tui::logic::input::help_editor::tests::the_axes_follow_the_vertical_faders`
  is the check on the axis swap: ←→ move the selection, ↑↓ do not. Every band is
  pinned to a rail so no keypress in the test reaches `config::save` or `eq::set`.
- `player::stream::eq::tests::labels_switch_to_kilohertz`
- `tui::logic::input::help_editor::tests::tab_cycles_the_three_pages`
- `tui::logic::input::help_editor::tests::a_band_stops_at_the_rails`
- `config::tests::eq_round_trip`, extended to cover the load-time clamp.

`cargo clippy --quiet --all-targets` — 21 warnings, byte-identical to the set on
`main` before this branch. Zero in any file this branch touches; `eq.rs`,
`config.rs`, `help.rs`, `help_editor.rs` and `state.rs` add none. `cargo fmt` not
run, per the repo's usual practice.

Smaller sizes, from the same `TestBackend` renders:

```
40×12 — three body rows, labels drop their units
     ╭──────── Equaliser ─────────╮
     │  +12 -12 +3   0  -5  +1    │
     │  ██      ▄▄                │
     │  ───────────────────────   │
     │      ██          ▀▀        │
     │  60  230 910 3k  8k  16k   │
     │                            │
     │                            │
     │↑↓: adjust   ←→: band   r: f│
     ╰────────────────────────────╯

30×10 — one body row: the numbers and the zero line, no fader travel
    ╭──── Equaliser ─────╮
    │+12 -12 +3   0  -5  │
    │────────────────────│
    │60  230 910 3k  8k  │
    │                    │
    │                    │
    │↑↓: adjust   ←→: ban│
    ╰────────────────────╯
```

## Not done

- **Not verified in a real terminal, and not verified with real audio.** There is
  no SoundCloud session available here, so nothing on this branch has been heard
  and the overlay has never been seen outside `TestBackend`. The filter maths is
  verified numerically against synthetic tones and the layout against rendered
  buffers at four sizes, but that a boost sounds like a boost through a live HLS
  stream — and that the faders look right in a real terminal's font — is
  unverified. Worth five minutes with a track playing before merging.
- **The `?` overlay is the only way in.** No keybinding jumps straight to the EQ
  page and no preset shapes (rock, vocal, …) — the issue asked for neither.
- **Fixed Q of 1.0** for all six bands, and fixed centre frequencies. Fine for
  tonal shaping; a parametric EQ would want both adjustable.
- **README not updated.** Its Configuration section documents themes and
  keybindings but not the settings page from #38 either, so adding only the EQ
  would be inconsistent; `--dump-config` documents `[eq]` inline. Say the word
  and I will add a section covering both pages.
- **Under ~33 columns the fader group is wider than the popup** and the paragraph
  clips it symmetrically — no panic, but the outer bands go missing. Carries a
  `ponytail:` note; paging the bands would be the fix if anyone runs a terminal
  that narrow.
- **Saves on every keypress**, as the settings and keys pages already do. Holding
  up or down rewrites config.toml once per decibel, though a nudge that hits the
  rail is a no-op and writes nothing.

