### PR TITLE
feat: configurable crossfade between tracks

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,23 +20,78 @@ pub struct Loaded {
     pub warnings: Vec<String>,
 }
 
-/// On/off options, edited from the settings page of the `?` overlay.
-#[derive(Deserialize, Serialize, Default, Clone, Copy)]
+/// Options edited from the settings page of the `?` overlay.
+#[derive(Deserialize, Serialize, Clone, Copy)]
 #[serde(default)]
 pub struct Settings {
     pub hide_unplayable: bool,
     pub hide_feed_tab: bool,
+    pub crossfade: bool,
+    pub crossfade_secs: u8,
 }
 
-/// One row of the settings page: its label and the field it toggles.
-pub type SettingRow = (&'static str, fn(&mut Settings) -> &mut bool);
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            hide_unplayable: false,
+            hide_feed_tab: false,
+            crossfade: false,
+            crossfade_secs: 5,
+        }
+    }
+}
+
+/// One row of the settings page: its label and the field it edits.
+#[derive(Clone, Copy)]
+pub enum SettingRow {
+    /// Flipped with Enter or Space.
+    Toggle(&'static str, fn(&mut Settings) -> &mut bool),
+    /// A whole number of seconds, adjusted with left/right.
+    Secs(&'static str, fn(&mut Settings) -> &mut u8),
+}
 
 impl Settings {
     /// The settings page, in display order.
-    pub const ROWS: [SettingRow; 2] = [
-        ("Hide unplayable tracks", |s| &mut s.hide_unplayable),
-        ("Hide feed tab", |s| &mut s.hide_feed_tab),
+    pub const ROWS: [SettingRow; 4] = [
+        SettingRow::Toggle("Hide unplayable tracks", |s| &mut s.hide_unplayable),
+        SettingRow::Toggle("Hide feed tab", |s| &mut s.hide_feed_tab),
+        SettingRow::Toggle("Crossfade between tracks", |s| &mut s.crossfade),
+        SettingRow::Secs("Crossfade duration", |s| &mut s.crossfade_secs),
     ];
+
+    pub const CROSSFADE_SECS_MIN: u8 = 1;
+    pub const CROSSFADE_SECS_MAX: u8 = 12;
+
+    /// How long one track should overlap the next, or 0 when crossfading is off
+    /// (the player then keeps only its own click-avoidance fade).
+    pub fn crossfade_ms(&self) -> u64 {
+        if self.crossfade {
+            let secs = self.crossfade_secs.clamp(Self::CROSSFADE_SECS_MIN, Self::CROSSFADE_SECS_MAX);
+            u64::from(secs) * 1000
+        } else {
+            0
+        }
+    }
+}
+
+impl SettingRow {
+    pub fn label(&self) -> &'static str {
+        match self {
+            SettingRow::Toggle(label, _) | SettingRow::Secs(label, _) => label,
+        }
+    }
+
+    /// The value column, and whether the row is actually in effect: a duration
+    /// nothing is using yet is dimmed the way an off toggle is.
+    pub fn display(&self, mut settings: Settings) -> (String, bool) {
+        match self {
+            SettingRow::Toggle(_, field) => {
+                let on = *field(&mut settings);
+                ((if on { "on" } else { "off" }).to_string(), on)
+            }
+            SettingRow::Secs(_, field) => (format!("{}s", field(&mut settings)), settings.crossfade),
+        }
+    }
 }
 
 #[derive(Deserialize, Default)]
@@ -125,7 +180,7 @@ pub fn template() -> String {
     out.push_str(".\n# [theme.colors] overrides single roles with \"#rrggbb\" or a colour name: ");
     out.push_str(&theme::ROLES.join(", "));
     out.push_str(".\n[theme]\nname = \"default\"\n# [theme.colors]\n# accent = \"#7aa2f7\"\n\n");
-    out.push_str("# On/off options, also editable in the app (? then Tab).\n[settings]\n");
+    out.push_str("# Options also editable in the app (? then Tab). crossfade_secs is 1-12.\n[settings]\n");
     out.push_str(&settings_section(&Settings::default()));
     out.push('\n');
     out.push_str(&Keymap::default().keys_section(false));
@@ -151,18 +206,43 @@ mod tests {
         assert!(file.theme.colors.0.is_empty());
         assert!(!file.settings.hide_unplayable);
         assert!(!file.settings.hide_feed_tab);
+        assert!(!file.settings.crossfade);
+        assert_eq!(file.settings.crossfade_secs, Settings::default().crossfade_secs);
     }
 
     #[test]
     fn settings_round_trip() {
         let mut settings = Settings::default();
-        for (_, field) in Settings::ROWS {
-            *field(&mut settings) = true;
+        for row in &Settings::ROWS {
+            match row {
+                SettingRow::Toggle(_, field) => *field(&mut settings) = true,
+                SettingRow::Secs(_, field) => *field(&mut settings) = 9,
+            }
         }
         let text = format!("[settings]\n{}", settings_section(&settings));
         let file: File = toml::from_str(&text).unwrap();
         assert!(file.settings.hide_unplayable);
         assert!(file.settings.hide_feed_tab);
+        assert!(file.settings.crossfade);
+        assert_eq!(file.settings.crossfade_secs, 9);
+    }
+
+    /// A config file written before crossfading existed has neither key, so the
+    /// defaults have to fill in; a hand-edited nonsense duration must not reach
+    /// the player.
+    #[test]
+    fn crossfade_duration_defaults_and_clamps() {
+        let file: File = toml::from_str("[settings]\nhide_feed_tab = true\n").unwrap();
+        assert_eq!(file.settings.crossfade_secs, 5);
+        assert_eq!(file.settings.crossfade_ms(), 0, "off means no crossfade");
+
+        let mut settings = file.settings;
+        settings.crossfade = true;
+        assert_eq!(settings.crossfade_ms(), 5_000);
+        settings.crossfade_secs = 200;
+        assert_eq!(settings.crossfade_ms(), u64::from(Settings::CROSSFADE_SECS_MAX) * 1000);
+        settings.crossfade_secs = 0;
+        assert_eq!(settings.crossfade_ms(), u64::from(Settings::CROSSFADE_SECS_MIN) * 1000);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ pub struct Settings {
     pub hide_feed_tab: bool,
     pub crossfade: bool,
     pub crossfade_secs: u8,
+    pub crossfade_user_skips: bool,
 }
 
 impl Default for Settings {
@@ -37,6 +38,7 @@ impl Default for Settings {
             hide_feed_tab: false,
             crossfade: false,
             crossfade_secs: 5,
+            crossfade_user_skips: true,
         }
     }
 }
@@ -46,17 +48,23 @@ impl Default for Settings {
 pub enum SettingRow {
     /// Flipped with Enter or Space.
     Toggle(&'static str, fn(&mut Settings) -> &mut bool),
+    /// The same, but only meaningful while crossfading is on: shown dimmed
+    /// alongside the duration whenever it is not.
+    CrossfadeToggle(&'static str, fn(&mut Settings) -> &mut bool),
     /// A whole number of seconds, adjusted with left/right.
     Secs(&'static str, fn(&mut Settings) -> &mut u8),
 }
 
 impl Settings {
     /// The settings page, in display order.
-    pub const ROWS: [SettingRow; 4] = [
+    pub const ROWS: [SettingRow; 5] = [
         SettingRow::Toggle("Hide unplayable tracks", |s| &mut s.hide_unplayable),
         SettingRow::Toggle("Hide feed tab", |s| &mut s.hide_feed_tab),
         SettingRow::Toggle("Crossfade between tracks", |s| &mut s.crossfade),
         SettingRow::Secs("Crossfade duration", |s| &mut s.crossfade_secs),
+        SettingRow::CrossfadeToggle("Crossfade applies to user-skips", |s| {
+            &mut s.crossfade_user_skips
+        }),
     ];
 
     pub const CROSSFADE_SECS_MIN: u8 = 1;
@@ -77,7 +85,9 @@ impl Settings {
 impl SettingRow {
     pub fn label(&self) -> &'static str {
         match self {
-            SettingRow::Toggle(label, _) | SettingRow::Secs(label, _) => label,
+            SettingRow::Toggle(label, _)
+            | SettingRow::CrossfadeToggle(label, _)
+            | SettingRow::Secs(label, _) => label,
         }
     }
 
@@ -88,6 +98,13 @@ impl SettingRow {
             SettingRow::Toggle(_, field) => {
                 let on = *field(&mut settings);
                 ((if on { "on" } else { "off" }).to_string(), on)
+            }
+            SettingRow::CrossfadeToggle(_, field) => {
+                let on = *field(&mut settings);
+                (
+                    (if on { "on" } else { "off" }).to_string(),
+                    on && settings.crossfade,
+                )
             }
             SettingRow::Secs(_, field) => (format!("{}s", field(&mut settings)), settings.crossfade),
         }
@@ -208,6 +225,7 @@ mod tests {
         assert!(!file.settings.hide_feed_tab);
         assert!(!file.settings.crossfade);
         assert_eq!(file.settings.crossfade_secs, Settings::default().crossfade_secs);
+        assert!(file.settings.crossfade_user_skips);
     }
 
     #[test]
@@ -215,7 +233,9 @@ mod tests {
         let mut settings = Settings::default();
         for row in &Settings::ROWS {
             match row {
-                SettingRow::Toggle(_, field) => *field(&mut settings) = true,
+                SettingRow::Toggle(_, field) | SettingRow::CrossfadeToggle(_, field) => {
+                    *field(&mut settings) = true
+                }
                 SettingRow::Secs(_, field) => *field(&mut settings) = 9,
             }
         }
@@ -225,6 +245,7 @@ mod tests {
         assert!(file.settings.hide_feed_tab);
         assert!(file.settings.crossfade);
         assert_eq!(file.settings.crossfade_secs, 9);
+        assert!(file.settings.crossfade_user_skips);
     }
 
     /// A config file written before crossfading existed has neither key, so the
@@ -234,6 +255,7 @@ mod tests {
     fn crossfade_duration_defaults_and_clamps() {
         let file: File = toml::from_str("[settings]\nhide_feed_tab = true\n").unwrap();
         assert_eq!(file.settings.crossfade_secs, 5);
+        assert!(file.settings.crossfade_user_skips, "a skip crossfades once crossfading is on");
         assert_eq!(file.settings.crossfade_ms(), 0, "off means no crossfade");
 
         let mut settings = file.settings;
@@ -243,6 +265,22 @@ mod tests {
         assert_eq!(settings.crossfade_ms(), u64::from(Settings::CROSSFADE_SECS_MAX) * 1000);
         settings.crossfade_secs = 0;
         assert_eq!(settings.crossfade_ms(), u64::from(Settings::CROSSFADE_SECS_MIN) * 1000);
+    }
+
+    /// The user-skip row says nothing while there is no crossfade to apply, so
+    /// it is dimmed with the duration until the toggle above it is on.
+    #[test]
+    fn the_user_skip_row_is_dimmed_until_crossfading_is_on() {
+        let row = Settings::ROWS
+            .iter()
+            .find(|r| matches!(r, SettingRow::CrossfadeToggle(..)))
+            .expect("the user-skip row is on the settings page");
+        let mut settings = Settings::default();
+        assert_eq!(row.display(settings), ("on".to_string(), false));
+        settings.crossfade = true;
+        assert_eq!(row.display(settings), ("on".to_string(), true));
+        settings.crossfade_user_skips = false;
+        assert_eq!(row.display(settings), ("off".to_string(), false));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,8 @@ pub struct Settings {
     pub hide_unplayable: bool,
     pub hide_feed_tab: bool,
     pub crossfade: bool,
-    pub crossfade_secs: u8,
+    #[serde(deserialize_with = "de_secs")]
+    pub crossfade_secs: f32,
     pub crossfade_user_skips: bool,
 }
 
@@ -37,10 +38,26 @@ impl Default for Settings {
             hide_unplayable: false,
             hide_feed_tab: false,
             crossfade: false,
-            crossfade_secs: 5,
+            crossfade_secs: 5.0,
             crossfade_user_skips: true,
         }
     }
+}
+
+/// Accepts a whole number as well as a decimal, so a config written before
+/// half-second steps existed (`crossfade_secs = 5`) still loads. A type error here
+/// would fail the whole `[settings]` table and silently reset every option in it.
+fn de_secs<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<f32, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Secs {
+        Decimal(f32),
+        Whole(i64),
+    }
+    Ok(match Secs::deserialize(deserializer)? {
+        Secs::Decimal(secs) => secs,
+        Secs::Whole(secs) => secs as f32,
+    })
 }
 
 /// One row of the settings page: its label and the field it edits.
@@ -51,8 +68,8 @@ pub enum SettingRow {
     /// The same, but only meaningful while crossfading is on: shown dimmed
     /// alongside the duration whenever it is not.
     CrossfadeToggle(&'static str, fn(&mut Settings) -> &mut bool),
-    /// A whole number of seconds, adjusted with left/right.
-    Secs(&'static str, fn(&mut Settings) -> &mut u8),
+    /// A number of seconds in half-second steps, adjusted with left/right.
+    Secs(&'static str, fn(&mut Settings) -> &mut f32),
 }
 
 impl Settings {
@@ -67,15 +84,28 @@ impl Settings {
         }),
     ];
 
-    pub const CROSSFADE_SECS_MIN: u8 = 1;
-    pub const CROSSFADE_SECS_MAX: u8 = 12;
+    pub const CROSSFADE_SECS_MIN: f32 = 0.5;
+    pub const CROSSFADE_SECS_MAX: f32 = 12.0;
+    /// Left/right moves the duration by this much.
+    pub const CROSSFADE_SECS_STEP: f32 = 0.5;
+
+    /// The duration as the settings page treats it: nonsense from a hand-edited file
+    /// falls back to the default, and anything off the half-second grid snaps onto it.
+    pub fn crossfade_secs_snapped(&self) -> f32 {
+        let secs = if self.crossfade_secs.is_finite() {
+            self.crossfade_secs
+        } else {
+            Self::default().crossfade_secs
+        };
+        let step = Self::CROSSFADE_SECS_STEP;
+        ((secs / step).round() * step).clamp(Self::CROSSFADE_SECS_MIN, Self::CROSSFADE_SECS_MAX)
+    }
 
     /// How long one track should overlap the next, or 0 when crossfading is off
     /// (the player then keeps only its own click-avoidance fade).
     pub fn crossfade_ms(&self) -> u64 {
         if self.crossfade {
-            let secs = self.crossfade_secs.clamp(Self::CROSSFADE_SECS_MIN, Self::CROSSFADE_SECS_MAX);
-            u64::from(secs) * 1000
+            (self.crossfade_secs_snapped() * 1000.0).round() as u64
         } else {
             0
         }
@@ -106,7 +136,9 @@ impl SettingRow {
                     on && settings.crossfade,
                 )
             }
-            SettingRow::Secs(_, field) => (format!("{}s", field(&mut settings)), settings.crossfade),
+            SettingRow::Secs(_, field) => {
+                (format!("{:.1}s", field(&mut settings)), settings.crossfade)
+            }
         }
     }
 }
@@ -197,7 +229,7 @@ pub fn template() -> String {
     out.push_str(".\n# [theme.colors] overrides single roles with \"#rrggbb\" or a colour name: ");
     out.push_str(&theme::ROLES.join(", "));
     out.push_str(".\n[theme]\nname = \"default\"\n# [theme.colors]\n# accent = \"#7aa2f7\"\n\n");
-    out.push_str("# Options also editable in the app (? then Tab). crossfade_secs is 1-12.\n[settings]\n");
+    out.push_str("# Options also editable in the app (? then Tab). crossfade_secs is 0.5-12, in half-second steps.\n[settings]\n");
     out.push_str(&settings_section(&Settings::default()));
     out.push('\n');
     out.push_str(&Keymap::default().keys_section(false));
@@ -236,7 +268,7 @@ mod tests {
                 SettingRow::Toggle(_, field) | SettingRow::CrossfadeToggle(_, field) => {
                     *field(&mut settings) = true
                 }
-                SettingRow::Secs(_, field) => *field(&mut settings) = 9,
+                SettingRow::Secs(_, field) => *field(&mut settings) = 9.5,
             }
         }
         let text = format!("[settings]\n{}", settings_section(&settings));
@@ -244,7 +276,7 @@ mod tests {
         assert!(file.settings.hide_unplayable);
         assert!(file.settings.hide_feed_tab);
         assert!(file.settings.crossfade);
-        assert_eq!(file.settings.crossfade_secs, 9);
+        assert_eq!(file.settings.crossfade_secs, 9.5);
         assert!(file.settings.crossfade_user_skips);
     }
 
@@ -254,17 +286,46 @@ mod tests {
     #[test]
     fn crossfade_duration_defaults_and_clamps() {
         let file: File = toml::from_str("[settings]\nhide_feed_tab = true\n").unwrap();
-        assert_eq!(file.settings.crossfade_secs, 5);
+        assert_eq!(file.settings.crossfade_secs, 5.0);
         assert!(file.settings.crossfade_user_skips, "a skip crossfades once crossfading is on");
         assert_eq!(file.settings.crossfade_ms(), 0, "off means no crossfade");
 
         let mut settings = file.settings;
         settings.crossfade = true;
         assert_eq!(settings.crossfade_ms(), 5_000);
-        settings.crossfade_secs = 200;
-        assert_eq!(settings.crossfade_ms(), u64::from(Settings::CROSSFADE_SECS_MAX) * 1000);
-        settings.crossfade_secs = 0;
-        assert_eq!(settings.crossfade_ms(), u64::from(Settings::CROSSFADE_SECS_MIN) * 1000);
+        settings.crossfade_secs = 200.0;
+        assert_eq!(settings.crossfade_ms(), 12_000);
+        settings.crossfade_secs = 0.0;
+        assert_eq!(settings.crossfade_ms(), 500);
+        settings.crossfade_secs = f32::NAN;
+        assert_eq!(settings.crossfade_ms(), 5_000, "nonsense falls back to the default");
+    }
+
+    /// Half-second steps: the value survives a round trip through the file, an older
+    /// whole-number config still loads, and anything off the grid snaps onto it.
+    #[test]
+    fn crossfade_duration_takes_half_seconds() {
+        let mut settings = Settings {
+            crossfade: true,
+            crossfade_secs: 2.5,
+            ..Default::default()
+        };
+        assert_eq!(settings.crossfade_ms(), 2_500);
+
+        let text = format!("[settings]\n{}", settings_section(&settings));
+        let file: File = toml::from_str(&text).unwrap();
+        assert_eq!(file.settings.crossfade_secs, 2.5, "a decimal survives the round trip");
+
+        // Written before half-second steps existed: a bare integer must still parse,
+        // and must not take the rest of [settings] down with it.
+        let older: File =
+            toml::from_str("[settings]\ncrossfade = true\ncrossfade_secs = 7\n").unwrap();
+        assert_eq!(older.settings.crossfade_secs, 7.0);
+        assert_eq!(older.settings.crossfade_ms(), 7_000);
+        assert!(older.settings.crossfade, "the rest of the table still loaded");
+
+        settings.crossfade_secs = 3.7;
+        assert_eq!(settings.crossfade_secs_snapped(), 3.5, "snapped onto the half-second grid");
     }
 
     /// The user-skip row says nothing while there is no crossfade to apply, so

--- a/src/player/commands.rs
+++ b/src/player/commands.rs
@@ -5,6 +5,8 @@ pub enum PlayerCommand {
     PreloadNext(Track),
     Pause,
     Resume,
+    /// Crossfade length in milliseconds, 0 for no crossfade.
+    SetCrossfade(u64),
     VolumeUp,
     VolumeDown,
     FastForward,

--- a/src/player/commands.rs
+++ b/src/player/commands.rs
@@ -1,12 +1,26 @@
 use crate::api::Track;
 
+/// What prompted a change of track. A natural handover always crossfades (when
+/// crossfading is on at all); a user skip only does when the user asked for
+/// that; a seek never does — it keeps its own click-avoidance fade.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TrackChange {
+    /// The track ran out and its successor is taking over.
+    Natural,
+    /// The user picked a different track: next, previous, or Enter on a row.
+    UserSkip,
+    /// Same track, new position.
+    Seek,
+}
+
 pub enum PlayerCommand {
-    Play(Track),
+    Play(Track, TrackChange),
     PreloadNext(Track),
     Pause,
     Resume,
-    /// Crossfade length in milliseconds, 0 for no crossfade.
-    SetCrossfade(u64),
+    /// Crossfade length in milliseconds (0 for no crossfade), and whether it
+    /// applies to user skips as well as natural handovers.
+    SetCrossfade { ms: u64, on_user_skips: bool },
     VolumeUp,
     VolumeDown,
     FastForward,

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -69,6 +69,12 @@ impl Player {
         }
     }
 
+    /// Set the crossfade length, in milliseconds; 0 turns crossfading off.
+    /// Takes effect at the next track change.
+    pub fn set_crossfade_ms(&self, ms: u64) {
+        let _ = self.tx.send(PlayerCommand::SetCrossfade(ms));
+    }
+
     pub fn play(&self, track: Track) {
         let _ = self.tx.send(PlayerCommand::Play(track));
     }

--- a/src/player/controller.rs
+++ b/src/player/controller.rs
@@ -10,7 +10,7 @@ use std::sync::{
 use std::thread;
 use std::time::{Duration, Instant};
 
-use super::commands::PlayerCommand;
+use super::commands::{PlayerCommand, TrackChange};
 use super::worker::player_loop;
 
 #[derive(Default)]
@@ -69,14 +69,17 @@ impl Player {
         }
     }
 
-    /// Set the crossfade length, in milliseconds; 0 turns crossfading off.
-    /// Takes effect at the next track change.
-    pub fn set_crossfade_ms(&self, ms: u64) {
-        let _ = self.tx.send(PlayerCommand::SetCrossfade(ms));
+    /// Set the crossfade length, in milliseconds (0 turns crossfading off), and
+    /// whether it applies to user skips. Takes effect at the next track change.
+    pub fn set_crossfade(&self, ms: u64, on_user_skips: bool) {
+        let _ = self.tx.send(PlayerCommand::SetCrossfade { ms, on_user_skips });
     }
 
-    pub fn play(&self, track: Track) {
-        let _ = self.tx.send(PlayerCommand::Play(track));
+    /// `change` says whether this is the queue moving on by itself or the user
+    /// asking for a different track; the engine needs it to decide whether the
+    /// crossfade applies.
+    pub fn play(&self, track: Track, change: TrackChange) {
+        let _ = self.tx.send(PlayerCommand::Play(track, change));
     }
 
     pub fn pause(&self) {

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -3,5 +3,6 @@ mod controller;
 mod stream;
 mod worker;
 
+pub use commands::TrackChange;
 pub use controller::Player;
 pub(crate) use controller::Position;

--- a/src/player/stream/downloader.rs
+++ b/src/player/stream/downloader.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use crate::auth::Token;
 use crate::player::Position;
 use crate::player::stream::cache::SegmentCache;
+use crate::player::stream::engine::is_live;
 use crate::player::stream::hls::{HlsManifest, resolve_manifest};
 
 pub(crate) const PREFETCH_SEGMENTS: usize = 3;
@@ -22,6 +23,9 @@ const MAX_REFRESHES: usize = 2;
 pub(crate) struct SegmentPumpParams {
     pub client: reqwest::blocking::Client,
     pub generation: Arc<AtomicU64>,
+    /// The one older generation still allowed to run: the track fading out
+    /// behind this one. See `engine::is_live`.
+    pub fading: Arc<AtomicU64>,
     pub generation_value: u64,
     pub manifest: Arc<HlsManifest>,
     pub segment_cache: Arc<Mutex<SegmentCache>>,
@@ -93,6 +97,7 @@ pub(crate) fn spawn_segment_pump(params: SegmentPumpParams) {
         let SegmentPumpParams {
             client,
             generation,
+            fading,
             generation_value,
             mut manifest,
             segment_cache,
@@ -104,7 +109,7 @@ pub(crate) fn spawn_segment_pump(params: SegmentPumpParams) {
             token,
         } = params;
 
-        let is_cancelled = || generation.load(Ordering::SeqCst) != generation_value;
+        let is_cancelled = || !is_live(&generation, &fading, generation_value);
 
         let mut next_index = start_segment_index.saturating_add(1);
         while next_index < manifest.segments.len() {

--- a/src/player/stream/engine.rs
+++ b/src/player/stream/engine.rs
@@ -17,8 +17,14 @@ use crate::player::stream::downloader::spawn_segment_pump;
 use crate::player::stream::reader::{PcmSource, SegmentReader};
 use crate::player::stream::sample::TapSource;
 
+/// Shortest fade used at a track change: long enough to lose the click of a
+/// sink stopping mid-waveform, short enough to pass for an instant cut.
 pub(crate) const CROSSFADE_DURATION: Duration = Duration::from_millis(35);
-const CROSSFADE_STEPS: usize = 7;
+/// One volume step per 5 ms, up to this many, so a 12 s crossfade is a few
+/// hundred steps rather than a few thousand.
+const MAX_FADE_STEPS: u64 = 240;
+/// No generation: generations start at 1, so this never matches a real one.
+const NO_GENERATION: u64 = 0;
 /// Decoded audio handed to the output in chunks of this many samples; the
 /// channel holds PCM_CHUNKS of them (~1.5 s of stereo 44.1 kHz) as look-ahead.
 const PCM_CHUNK_SAMPLES: usize = 2048;
@@ -33,8 +39,23 @@ pub(crate) struct PlaybackEngine {
     stream: Arc<Mutex<OutputStream>>,
     client: reqwest::blocking::Client,
     generation: Arc<AtomicU64>,
+    /// The one superseded generation still allowed to run, because it is
+    /// crossfading out behind the current track. See [`is_live`].
+    fading: Arc<AtomicU64>,
+    /// User-chosen crossfade length in milliseconds, 0 when switched off.
+    crossfade_ms: u64,
     cache: Option<CachedHls>,
     preload_next: Option<CachedHls>,
+}
+
+/// Whether the decode and download threads of `generation_value` are still
+/// wanted. Everything belonging to a replaced track normally stops the moment
+/// the generation moves on; during a crossfade the outgoing track has to keep
+/// decoding and downloading until its fade ends, or it would run out of
+/// buffered audio part way through.
+pub(crate) fn is_live(generation: &AtomicU64, fading: &AtomicU64, generation_value: u64) -> bool {
+    generation.load(Ordering::SeqCst) == generation_value
+        || fading.load(Ordering::SeqCst) == generation_value
 }
 
 impl PlaybackEngine {
@@ -49,9 +70,15 @@ impl PlaybackEngine {
             stream,
             client,
             generation: Arc::new(AtomicU64::new(0)),
+            fading: Arc::new(AtomicU64::new(NO_GENERATION)),
+            crossfade_ms: 0,
             cache: None,
             preload_next: None,
         })
+    }
+
+    pub(crate) fn set_crossfade_ms(&mut self, ms: u64) {
+        self.crossfade_ms = ms;
     }
 
     fn bump_generation(&self) -> u64 {
@@ -194,11 +221,22 @@ impl PlaybackEngine {
             (guard.is_some(), vol)
         };
 
-        let planned_generation = self.current_generation().wrapping_add(1);
+        // A crossfade leaves the outgoing track playing while its replacement
+        // loads and fades up, so it keeps its sink and its threads for now. With
+        // crossfading off, a track change is still a clean stop.
+        let crossfade = Duration::from_millis(self.crossfade_ms);
+        let overlap = !is_seek && has_old_sink && !crossfade.is_zero();
+        let outgoing_generation = self.current_generation();
+        let fading = Arc::clone(&self.fading);
+
+        let planned_generation = outgoing_generation.wrapping_add(1);
         if !is_seek {
+            if overlap {
+                fading.store(outgoing_generation, Ordering::SeqCst);
+            }
             let generation_id = self.bump_generation();
             debug_assert_eq!(generation_id, planned_generation);
-            if let Some(ref s) = *sink_arc.lock().unwrap() {
+            if !overlap && let Some(ref s) = *sink_arc.lock().unwrap() {
                 s.stop();
             }
         }
@@ -206,10 +244,7 @@ impl PlaybackEngine {
         let (manifest, init_bytes, segment_cache) = match self.ensure_cached_hls(track, token) {
             Ok(v) => v,
             Err(_) => {
-                if !is_seek {
-                    is_playing_flag.store(false, Ordering::SeqCst);
-                    position.lock().unwrap().last_start = None;
-                }
+                abort_switch(is_seek, sink_arc, is_playing_flag, position, &fading);
                 return;
             }
         };
@@ -233,10 +268,7 @@ impl PlaybackEngine {
                         // Most likely the cached manifest's signed URLs have expired;
                         // drop it so the next attempt resolves a fresh one.
                         self.cache = None;
-                        if !is_seek {
-                            is_playing_flag.store(false, Ordering::SeqCst);
-                            position.lock().unwrap().last_start = None;
-                        }
+                        abort_switch(is_seek, sink_arc, is_playing_flag, position, &fading);
                         return;
                     }
                 }
@@ -260,10 +292,7 @@ impl PlaybackEngine {
         {
             Ok(decoder) => decoder,
             Err(_) => {
-                if !is_seek {
-                    is_playing_flag.store(false, Ordering::SeqCst);
-                    position.lock().unwrap().last_start = None;
-                }
+                abort_switch(is_seek, sink_arc, is_playing_flag, position, &fading);
                 return;
             }
         };
@@ -274,7 +303,9 @@ impl PlaybackEngine {
             let stream_guard = self.stream.lock().unwrap();
             Sink::connect_new(stream_guard.mixer())
         };
-        new_sink.set_volume(target_volume);
+        // A crossfade brings the new track up from silence; otherwise it starts
+        // straight away at whatever volume the last one was playing at.
+        new_sink.set_volume(if overlap { 0.0 } else { target_volume });
 
         let gen_for_pump = if is_seek {
             let generation_id = self.bump_generation();
@@ -290,14 +321,17 @@ impl PlaybackEngine {
             Duration::from_millis(offset_within_segment_ms),
             pcm_tx,
             Arc::clone(&self.generation),
+            Arc::clone(&self.fading),
             gen_for_pump,
         );
         new_sink.append(TapSource::new(
             PcmSource::new(pcm_rx, channels, sample_rate),
             Arc::clone(wave_buffer),
+            Arc::clone(&self.generation),
+            gen_for_pump,
         ));
 
-        let old_sink_for_fade = if is_seek && has_old_sink {
+        let old_sink_for_fade = if (is_seek || overlap) && has_old_sink {
             sink_arc.lock().unwrap().take()
         } else {
             None
@@ -306,7 +340,19 @@ impl PlaybackEngine {
         *sink_arc.lock().unwrap() = Some(new_sink);
 
         if let Some(old_sink) = old_sink_for_fade {
-            crossfade_and_stop(old_sink, target_volume);
+            spawn_fade(Fade {
+                old_sink,
+                // A seek only needs the click taken off the end of the old sink;
+                // a track change fades the new one up as the old one goes down.
+                incoming: overlap.then(|| Arc::clone(sink_arc)),
+                duration: if overlap { crossfade } else { CROSSFADE_DURATION },
+                target_volume,
+                is_playing_flag: Arc::clone(is_playing_flag),
+                generation: Arc::clone(&self.generation),
+                incoming_generation: gen_for_pump,
+                fading,
+                fading_value: outgoing_generation,
+            });
         }
 
         {
@@ -321,6 +367,7 @@ impl PlaybackEngine {
         spawn_segment_pump(SegmentPumpParams {
             client: self.client.clone(),
             generation: Arc::clone(&self.generation),
+            fading: Arc::clone(&self.fading),
             generation_value: gen_for_pump,
             manifest,
             segment_cache,
@@ -342,6 +389,7 @@ fn spawn_decode_thread(
     skip: Duration,
     tx: SyncSender<Vec<f32>>,
     generation: Arc<AtomicU64>,
+    fading: Arc<AtomicU64>,
     generation_value: u64,
 ) {
     std::thread::spawn(move || {
@@ -356,7 +404,7 @@ fn spawn_decode_thread(
                 Some(sample) => {
                     chunk.push(sample);
                     if chunk.len() == PCM_CHUNK_SAMPLES {
-                        if generation.load(Ordering::SeqCst) != generation_value {
+                        if !is_live(&generation, &fading, generation_value) {
                             return;
                         }
                         let full = std::mem::replace(&mut chunk, Vec::with_capacity(PCM_CHUNK_SAMPLES));
@@ -376,15 +424,158 @@ fn spawn_decode_thread(
     });
 }
 
-fn crossfade_and_stop(old_sink: Sink, target_volume: f32) {
-    let total_ms = CROSSFADE_DURATION.as_millis() as u64;
-    let step_ms = (total_ms / CROSSFADE_STEPS as u64).max(1);
+struct Fade {
+    /// The track being replaced: stopped and dropped once the fade ends, which
+    /// is what finally releases its decode and download threads.
+    old_sink: Sink,
+    /// The sink to bring up at the same time, for a real crossfade. `None` for
+    /// a seek, where the replacement is already at full volume.
+    incoming: Option<Arc<Mutex<Option<Sink>>>>,
+    duration: Duration,
+    /// The volume the pair should end up at: whatever the user had set when the
+    /// switch started.
+    // ponytail: a volume change made during a long crossfade is overwritten
+    // until the fade ends; re-read it from the incoming sink each step if that
+    // ever grates.
+    target_volume: f32,
+    is_playing_flag: Arc<std::sync::atomic::AtomicBool>,
+    generation: Arc<AtomicU64>,
+    /// Generation of the incoming track. Once the generation moves past it the
+    /// sink in `incoming` belongs to someone else and is left alone.
+    incoming_generation: u64,
+    /// Reprieve granted to the outgoing generation, released when the fade ends.
+    fading: Arc<AtomicU64>,
+    fading_value: u64,
+}
 
-    for i in 0..=CROSSFADE_STEPS {
-        let t = i as f32 / CROSSFADE_STEPS as f32;
-        old_sink.set_volume(target_volume * (1.0 - t));
-        std::thread::sleep(Duration::from_millis(step_ms));
+/// Volume multipliers for the outgoing and incoming tracks `t` of the way
+/// through a fade. Two tracks playing at once are ramped on an equal-power
+/// curve, because summing uncorrelated audio through linear ramps dips
+/// audibly in the middle; a lone outgoing track just ramps straight down.
+fn fade_gains(t: f32, overlapping: bool) -> (f32, f32) {
+    if overlapping {
+        ((1.0 - t).sqrt(), t.sqrt())
+    } else {
+        (1.0 - t, 1.0)
+    }
+}
+
+/// How many volume steps to take over `duration`, and how long to hold each.
+fn fade_schedule(duration: Duration) -> (u64, Duration) {
+    let total_ms = (duration.as_millis() as u64).max(1);
+    let steps = (total_ms / 5).clamp(1, MAX_FADE_STEPS);
+    (steps, Duration::from_millis((total_ms / steps).max(1)))
+}
+
+/// Runs the fade off the player thread: a 12 s crossfade must not stop it
+/// answering pause, skip or volume for 12 seconds.
+fn spawn_fade(fade: Fade) {
+    std::thread::spawn(move || {
+        let (steps, step) = fade_schedule(fade.duration);
+        for i in 0..=steps {
+            // Pausing has to take the outgoing track with it; it is no longer
+            // the sink the player thread reaches for.
+            if fade.is_playing_flag.load(Ordering::SeqCst) {
+                fade.old_sink.play();
+            } else {
+                fade.old_sink.pause();
+            }
+
+            let (out_gain, in_gain) = fade_gains(i as f32 / steps as f32, fade.incoming.is_some());
+            fade.old_sink.set_volume(fade.target_volume * out_gain);
+            if let Some(sink_arc) = &fade.incoming {
+                if fade.generation.load(Ordering::SeqCst) != fade.incoming_generation {
+                    // Another track has taken over mid-fade and owns the volume
+                    // of whatever is in the sink now.
+                    break;
+                }
+                if let Some(sink) = sink_arc.lock().unwrap().as_ref() {
+                    sink.set_volume(fade.target_volume * in_gain);
+                }
+            }
+            std::thread::sleep(step);
+        }
+
+        fade.old_sink.stop();
+        let _ = fade.fading.compare_exchange(
+            fade.fading_value,
+            NO_GENERATION,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
+    });
+}
+
+/// A track change that failed part way through. The outgoing track may still be
+/// playing — a crossfade only stops it once its replacement is running — so stop
+/// it and report the player as idle. The sink itself stays in place: it carries
+/// the volume the next track will start at. A failed seek changed nothing, so it
+/// leaves the track that is playing alone.
+fn abort_switch(
+    is_seek: bool,
+    sink_arc: &Arc<Mutex<Option<Sink>>>,
+    is_playing_flag: &std::sync::atomic::AtomicBool,
+    position: &Mutex<Position>,
+    fading: &AtomicU64,
+) {
+    if is_seek {
+        return;
+    }
+    if let Some(sink) = sink_arc.lock().unwrap().as_ref() {
+        sink.stop();
+    }
+    fading.store(NO_GENERATION, Ordering::SeqCst);
+    is_playing_flag.store(false, Ordering::SeqCst);
+    position.lock().unwrap().last_start = None;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_crossfade_holds_a_steady_level_and_ends_swapped_over() {
+        let (out0, in0) = fade_gains(0.0, true);
+        assert!((out0 - 1.0).abs() < 1e-6 && in0 == 0.0, "starts on the outgoing track");
+        let (out1, in1) = fade_gains(1.0, true);
+        assert!(out1 == 0.0 && (in1 - 1.0).abs() < 1e-6, "ends on the incoming one");
+        for step in 0..=10 {
+            let (out, inc) = fade_gains(step as f32 / 10.0, true);
+            let power = out * out + inc * inc;
+            assert!((power - 1.0).abs() < 1e-5, "dip at t={step}: power {power}");
+        }
     }
 
-    old_sink.stop();
+    #[test]
+    fn a_fade_with_nothing_coming_in_just_ramps_down() {
+        assert_eq!(fade_gains(0.5, false), (0.5, 1.0));
+        assert_eq!(fade_gains(1.0, false), (0.0, 1.0));
+    }
+
+    #[test]
+    fn fade_steps_stay_bounded_and_span_the_whole_duration() {
+        // The click-avoidance fade keeps its original 5 ms steps.
+        assert_eq!(fade_schedule(CROSSFADE_DURATION), (7, Duration::from_millis(5)));
+        for ms in [1u64, 35, 500, 1_000, 12_000] {
+            let (steps, step) = fade_schedule(Duration::from_millis(ms));
+            assert!(steps <= MAX_FADE_STEPS, "{ms} ms takes {steps} steps");
+            let elapsed = steps * step.as_millis() as u64;
+            assert!(elapsed <= ms.max(1) && elapsed * 2 >= ms, "{ms} ms fade ran for {elapsed} ms");
+        }
+    }
+
+    #[test]
+    fn only_the_current_and_fading_out_generations_are_live() {
+        let generation = AtomicU64::new(4);
+        let fading = AtomicU64::new(NO_GENERATION);
+        assert!(is_live(&generation, &fading, 4));
+        assert!(!is_live(&generation, &fading, 3));
+
+        // Track 3 crossfading out behind track 4 keeps decoding until its fade ends.
+        fading.store(3, Ordering::SeqCst);
+        assert!(is_live(&generation, &fading, 3));
+        assert!(!is_live(&generation, &fading, 2));
+        fading.store(NO_GENERATION, Ordering::SeqCst);
+        assert!(!is_live(&generation, &fading, 3));
+    }
 }

--- a/src/player/stream/engine.rs
+++ b/src/player/stream/engine.rs
@@ -11,6 +11,7 @@ use reqwest::Url;
 use crate::api::Track;
 use crate::auth::Token;
 use crate::player::Position;
+use crate::player::commands::TrackChange;
 use crate::player::stream::cache::{CachedHls, SegmentCache};
 use crate::player::stream::hls::{HlsManifest, resolve_manifest};
 use crate::player::stream::downloader::spawn_segment_pump;
@@ -44,6 +45,8 @@ pub(crate) struct PlaybackEngine {
     fading: Arc<AtomicU64>,
     /// User-chosen crossfade length in milliseconds, 0 when switched off.
     crossfade_ms: u64,
+    /// Whether that crossfade also applies when the user skips tracks.
+    crossfade_on_user_skips: bool,
     cache: Option<CachedHls>,
     preload_next: Option<CachedHls>,
 }
@@ -56,6 +59,18 @@ pub(crate) struct PlaybackEngine {
 pub(crate) fn is_live(generation: &AtomicU64, fading: &AtomicU64, generation_value: u64) -> bool {
     generation.load(Ordering::SeqCst) == generation_value
         || fading.load(Ordering::SeqCst) == generation_value
+}
+
+/// Whether this particular change should overlap the outgoing track with the
+/// user's crossfade. A seek never does — it keeps the 35 ms click-avoidance
+/// fade it has always had, whatever the settings say.
+pub(crate) fn crossfade_applies(crossfade_ms: u64, on_user_skips: bool, change: TrackChange) -> bool {
+    crossfade_ms > 0
+        && match change {
+            TrackChange::Natural => true,
+            TrackChange::UserSkip => on_user_skips,
+            TrackChange::Seek => false,
+        }
 }
 
 impl PlaybackEngine {
@@ -72,13 +87,15 @@ impl PlaybackEngine {
             generation: Arc::new(AtomicU64::new(0)),
             fading: Arc::new(AtomicU64::new(NO_GENERATION)),
             crossfade_ms: 0,
+            crossfade_on_user_skips: true,
             cache: None,
             preload_next: None,
         })
     }
 
-    pub(crate) fn set_crossfade_ms(&mut self, ms: u64) {
+    pub(crate) fn set_crossfade(&mut self, ms: u64, on_user_skips: bool) {
         self.crossfade_ms = ms;
+        self.crossfade_on_user_skips = on_user_skips;
     }
 
     fn bump_generation(&self) -> u64 {
@@ -201,6 +218,7 @@ impl PlaybackEngine {
         &mut self,
         track: &Track,
         position_ms: u64,
+        change: TrackChange,
         token: &Arc<Mutex<Token>>,
         sink_arc: &Arc<Mutex<Option<Sink>>>,
         is_playing_flag: &Arc<std::sync::atomic::AtomicBool>,
@@ -213,7 +231,10 @@ impl PlaybackEngine {
             .track
             .as_ref()
             .map(|t| t.track_urn.clone());
+        // Replaying the same track (a seek, or repeat-one) is a reposition of what
+        // is already playing whatever the caller thought it was asking for.
         let is_seek = old_track_urn.as_deref() == Some(&track.track_urn);
+        let change = if is_seek { TrackChange::Seek } else { change };
 
         let (has_old_sink, target_volume) = {
             let guard = sink_arc.lock().unwrap();
@@ -225,7 +246,8 @@ impl PlaybackEngine {
         // loads and fades up, so it keeps its sink and its threads for now. With
         // crossfading off, a track change is still a clean stop.
         let crossfade = Duration::from_millis(self.crossfade_ms);
-        let overlap = !is_seek && has_old_sink && !crossfade.is_zero();
+        let overlap =
+            has_old_sink && crossfade_applies(self.crossfade_ms, self.crossfade_on_user_skips, change);
         let outgoing_generation = self.current_generation();
         let fading = Arc::clone(&self.fading);
 
@@ -562,6 +584,22 @@ mod tests {
             let elapsed = steps * step.as_millis() as u64;
             assert!(elapsed <= ms.max(1) && elapsed * 2 >= ms, "{ms} ms fade ran for {elapsed} ms");
         }
+    }
+
+    #[test]
+    fn the_crossfade_setting_decides_which_changes_overlap() {
+        for change in [TrackChange::Natural, TrackChange::UserSkip, TrackChange::Seek] {
+            assert!(!crossfade_applies(0, true, change), "crossfading off: {change:?}");
+        }
+        // On for everything: a natural handover and a skip both overlap.
+        assert!(crossfade_applies(5_000, true, TrackChange::Natural));
+        assert!(crossfade_applies(5_000, true, TrackChange::UserSkip));
+        // Off for skips: only a track ending of its own accord overlaps.
+        assert!(crossfade_applies(5_000, false, TrackChange::Natural));
+        assert!(!crossfade_applies(5_000, false, TrackChange::UserSkip));
+        // A seek is untouched by the setting either way.
+        assert!(!crossfade_applies(5_000, true, TrackChange::Seek));
+        assert!(!crossfade_applies(5_000, false, TrackChange::Seek));
     }
 
     #[test]

--- a/src/player/stream/sample.rs
+++ b/src/player/stream/sample.rs
@@ -1,17 +1,30 @@
 use rodio::Source;
 use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
 
 pub(crate) const WAVE_BUFFER_CAP: usize = 8192;
 
 pub(crate) struct TapSource<S> {
     inner: S,
     buffer: Arc<Mutex<VecDeque<f32>>>,
+    /// The visualizer follows one track at a time. A track crossfading out is
+    /// still audible but no longer the current generation, and two tracks
+    /// pushing samples into the same buffer interleave into noise.
+    generation: Arc<AtomicU64>,
+    generation_value: u64,
 }
 
 impl<S> TapSource<S> {
-    pub(crate) fn new(inner: S, buffer: Arc<Mutex<VecDeque<f32>>>) -> Self {
-        Self { inner, buffer }
+    pub(crate) fn new(
+        inner: S,
+        buffer: Arc<Mutex<VecDeque<f32>>>,
+        generation: Arc<AtomicU64>,
+        generation_value: u64,
+    ) -> Self {
+        Self { inner, buffer, generation, generation_value }
     }
 }
 
@@ -20,11 +33,13 @@ impl<S: Source> Iterator for TapSource<S> {
 
     fn next(&mut self) -> Option<f32> {
         let sample = self.inner.next()?;
-        let mut buffer = self.buffer.lock().unwrap();
-        if buffer.len() >= WAVE_BUFFER_CAP {
-            buffer.pop_front();
+        if self.generation.load(Ordering::SeqCst) == self.generation_value {
+            let mut buffer = self.buffer.lock().unwrap();
+            if buffer.len() >= WAVE_BUFFER_CAP {
+                buffer.pop_front();
+            }
+            buffer.push_back(sample);
         }
-        buffer.push_back(sample);
         Some(sample)
     }
 }
@@ -44,5 +59,33 @@ impl<S: Source> Source for TapSource<S> {
 
     fn total_duration(&self) -> Option<std::time::Duration> {
         self.inner.total_duration()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rodio::buffer::SamplesBuffer;
+
+    #[test]
+    fn a_superseded_track_keeps_playing_but_stops_feeding_the_visualizer() {
+        let buffer = Arc::new(Mutex::new(VecDeque::new()));
+        let generation = Arc::new(AtomicU64::new(1));
+        let mut tap = TapSource::new(
+            SamplesBuffer::new(1, 44_100, vec![0.1, 0.2, 0.3, 0.4]),
+            Arc::clone(&buffer),
+            Arc::clone(&generation),
+            1,
+        );
+
+        assert_eq!(tap.next(), Some(0.1));
+        assert_eq!(tap.next(), Some(0.2));
+        // The next track takes over; this one is now crossfading out.
+        generation.store(2, Ordering::SeqCst);
+        assert_eq!(tap.next(), Some(0.3), "still audible");
+        assert_eq!(tap.next(), Some(0.4));
+
+        let tapped: Vec<f32> = buffer.lock().unwrap().iter().copied().collect();
+        assert_eq!(tapped, vec![0.1, 0.2]);
     }
 }

--- a/src/player/worker.rs
+++ b/src/player/worker.rs
@@ -69,6 +69,8 @@ pub(crate) fn player_loop(
                 let _ = engine.preload_next_track(&track, &token);
             }
 
+            PlayerCommand::SetCrossfade(ms) => engine.set_crossfade_ms(ms),
+
             PlayerCommand::Pause => {
                 if let Some(ref s) = *sink_arc.lock().unwrap() {
                     s.pause();

--- a/src/player/worker.rs
+++ b/src/player/worker.rs
@@ -9,7 +9,7 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use super::Position;
-use super::commands::PlayerCommand;
+use super::commands::{PlayerCommand, TrackChange};
 use super::stream::{PlaybackEngine, open_output_stream};
 
 /// Pulls the next command to act on. Spam-skipping next/prev queues a burst of `Play`
@@ -22,10 +22,10 @@ fn next_command(rx: &Receiver<PlayerCommand>, pending: &mut Option<PlayerCommand
         Some(msg) => msg,
         None => rx.recv().ok()?,
     };
-    Some(if matches!(msg, PlayerCommand::Play(_)) {
+    Some(if matches!(msg, PlayerCommand::Play(..)) {
         let mut latest = msg;
         while let Ok(next) = rx.try_recv() {
-            if matches!(next, PlayerCommand::Play(_)) {
+            if matches!(next, PlayerCommand::Play(..)) {
                 latest = next;
             } else {
                 *pending = Some(next);
@@ -53,10 +53,11 @@ pub(crate) fn player_loop(
     let mut pending: Option<PlayerCommand> = None;
     while let Some(msg) = next_command(&rx, &mut pending) {
         match msg {
-            PlayerCommand::Play(track) => {
+            PlayerCommand::Play(track, change) => {
                 engine.play_from_position(
                     &track,
                     0,
+                    change,
                     &token,
                     &sink_arc,
                     &is_playing_flag,
@@ -69,7 +70,9 @@ pub(crate) fn player_loop(
                 let _ = engine.preload_next_track(&track, &token);
             }
 
-            PlayerCommand::SetCrossfade(ms) => engine.set_crossfade_ms(ms),
+            PlayerCommand::SetCrossfade { ms, on_user_skips } => {
+                engine.set_crossfade(ms, on_user_skips)
+            }
 
             PlayerCommand::Pause => {
                 if let Some(ref s) = *sink_arc.lock().unwrap() {
@@ -142,6 +145,7 @@ pub(crate) fn player_loop(
                         engine.play_from_position(
                             &track,
                             new_position_ms,
+                            TrackChange::Seek,
                             &token,
                             &sink_arc,
                             &is_playing_flag,
@@ -182,6 +186,7 @@ pub(crate) fn player_loop(
                     engine.play_from_position(
                         &track,
                         new_position_ms,
+                        TrackChange::Seek,
                         &token,
                         &sink_arc,
                         &is_playing_flag,
@@ -216,7 +221,7 @@ mod tests {
 
     fn urn(cmd: &PlayerCommand) -> &str {
         match cmd {
-            PlayerCommand::Play(t) => &t.track_urn,
+            PlayerCommand::Play(t, _) => &t.track_urn,
             _ => panic!("expected Play"),
         }
     }
@@ -224,9 +229,9 @@ mod tests {
     #[test]
     fn a_burst_of_plays_collapses_to_the_last_one() {
         let (tx, rx) = mpsc::channel();
-        tx.send(PlayerCommand::Play(track("a"))).unwrap();
-        tx.send(PlayerCommand::Play(track("b"))).unwrap();
-        tx.send(PlayerCommand::Play(track("c"))).unwrap();
+        tx.send(PlayerCommand::Play(track("a"), TrackChange::UserSkip)).unwrap();
+        tx.send(PlayerCommand::Play(track("b"), TrackChange::UserSkip)).unwrap();
+        tx.send(PlayerCommand::Play(track("c"), TrackChange::UserSkip)).unwrap();
 
         let mut pending = None;
         let msg = next_command(&rx, &mut pending).unwrap();
@@ -238,10 +243,10 @@ mod tests {
     #[test]
     fn a_non_play_command_after_a_burst_is_returned_next_in_order() {
         let (tx, rx) = mpsc::channel();
-        tx.send(PlayerCommand::Play(track("a"))).unwrap();
-        tx.send(PlayerCommand::Play(track("b"))).unwrap();
+        tx.send(PlayerCommand::Play(track("a"), TrackChange::UserSkip)).unwrap();
+        tx.send(PlayerCommand::Play(track("b"), TrackChange::UserSkip)).unwrap();
         tx.send(PlayerCommand::Pause).unwrap();
-        tx.send(PlayerCommand::Play(track("c"))).unwrap();
+        tx.send(PlayerCommand::Play(track("c"), TrackChange::UserSkip)).unwrap();
 
         let mut pending = None;
         let first = next_command(&rx, &mut pending).unwrap();
@@ -259,7 +264,7 @@ mod tests {
     #[test]
     fn single_play_with_nothing_queued_passes_through_unchanged() {
         let (tx, rx) = mpsc::channel();
-        tx.send(PlayerCommand::Play(track("only"))).unwrap();
+        tx.send(PlayerCommand::Play(track("only"), TrackChange::UserSkip)).unwrap();
         let mut pending = None;
         assert_eq!(urn(&next_command(&rx, &mut pending).unwrap()), "only");
     }

--- a/src/tui/logic/input/help_editor.rs
+++ b/src/tui/logic/input/help_editor.rs
@@ -1,8 +1,9 @@
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
 use super::InputOutcome;
-use crate::config::Settings;
+use crate::config::{SettingRow, Settings};
 use crate::keymap::{Action, Chord};
+use crate::player::Player;
 use crate::tui::logic::filtering::apply_unplayable_filter;
 use crate::tui::logic::state::{AppData, AppState, visible_tabs};
 
@@ -12,6 +13,7 @@ pub(crate) fn handle_help_input(
     key: KeyEvent,
     state: &mut AppState,
     data: &mut AppData,
+    player: &Player,
 ) -> InputOutcome {
     let last = Action::ALL.len() - 1;
     let selected = Action::ALL[state.help_selected.min(last)];
@@ -36,7 +38,7 @@ pub(crate) fn handle_help_input(
         return InputOutcome::Continue;
     }
     if state.help_settings {
-        return handle_settings_input(key, state, data);
+        return handle_settings_input(key, state, data, player);
     }
 
     state.help_message = None;
@@ -69,23 +71,33 @@ pub(crate) fn handle_help_input(
     InputOutcome::Continue
 }
 
-/// The settings page: Enter or Space flips the highlighted toggle.
-fn handle_settings_input(key: KeyEvent, state: &mut AppState, data: &mut AppData) -> InputOutcome {
+/// The settings page: Enter or Space flips the highlighted toggle, left/right
+/// nudges the highlighted duration.
+fn handle_settings_input(
+    key: KeyEvent,
+    state: &mut AppState,
+    data: &mut AppData,
+    player: &Player,
+) -> InputOutcome {
     let last = Settings::ROWS.len() - 1;
+    let row = Settings::ROWS[state.help_settings_selected.min(last)];
     state.help_message = None;
     match (key.code, state.keymap.action(&key)) {
         (KeyCode::Esc, _) | (_, Some(Action::Help)) => state.help_visible = false,
         (KeyCode::Enter | KeyCode::Char(' '), _) => {
-            let (label, field) = Settings::ROWS[state.help_settings_selected.min(last)];
-            let value = {
-                let flag = field(&mut state.settings);
-                *flag = !*flag;
-                *flag
-            };
-            apply_settings(state, data);
-            let on = if value { "on" } else { "off" };
-            state.help_message = Some(saved(state, format!("{label}: {on}")));
+            if let SettingRow::Toggle(label, field) = row {
+                let value = {
+                    let flag = field(&mut state.settings);
+                    *flag = !*flag;
+                    *flag
+                };
+                apply_settings(state, data, player);
+                let on = if value { "on" } else { "off" };
+                state.help_message = Some(saved(state, format!("{label}: {on}")));
+            }
         }
+        (KeyCode::Left, _) | (_, Some(Action::SubTabLeft)) => adjust(row, state, data, player, -1),
+        (KeyCode::Right, _) | (_, Some(Action::SubTabRight)) => adjust(row, state, data, player, 1),
         (_, Some(Action::Up)) | (KeyCode::Up, _) => {
             state.help_settings_selected = state.help_settings_selected.saturating_sub(1)
         }
@@ -99,13 +111,29 @@ fn handle_settings_input(key: KeyEvent, state: &mut AppState, data: &mut AppData
     InputOutcome::Continue
 }
 
-/// Make a just-flipped setting take effect on what is already loaded.
-fn apply_settings(state: &mut AppState, data: &mut AppData) {
+/// Move a duration row by `delta` seconds, within its allowed range.
+fn adjust(row: SettingRow, state: &mut AppState, data: &mut AppData, player: &Player, delta: i16) {
+    let SettingRow::Secs(label, field) = row else { return };
+    let secs = {
+        let value = field(&mut state.settings);
+        *value = (i16::from(*value) + delta).clamp(
+            i16::from(Settings::CROSSFADE_SECS_MIN),
+            i16::from(Settings::CROSSFADE_SECS_MAX),
+        ) as u8;
+        *value
+    };
+    apply_settings(state, data, player);
+    state.help_message = Some(saved(state, format!("{label}: {secs}s")));
+}
+
+/// Make a just-changed setting take effect on what is already loaded.
+fn apply_settings(state: &mut AppState, data: &mut AppData, player: &Player) {
     apply_unplayable_filter(state, data);
     if state.selected_tab >= visible_tabs(state).len() {
         state.selected_tab = 0;
         state.selected_row = 0;
     }
+    player.set_crossfade_ms(state.settings.crossfade_ms());
 }
 
 /// Persist and decorate the message with the outcome.

--- a/src/tui/logic/input/help_editor.rs
+++ b/src/tui/logic/input/help_editor.rs
@@ -85,7 +85,7 @@ fn handle_settings_input(
     match (key.code, state.keymap.action(&key)) {
         (KeyCode::Esc, _) | (_, Some(Action::Help)) => state.help_visible = false,
         (KeyCode::Enter | KeyCode::Char(' '), _) => {
-            if let SettingRow::Toggle(label, field) = row {
+            if let SettingRow::Toggle(label, field) | SettingRow::CrossfadeToggle(label, field) = row {
                 let value = {
                     let flag = field(&mut state.settings);
                     *flag = !*flag;
@@ -133,7 +133,7 @@ fn apply_settings(state: &mut AppState, data: &mut AppData, player: &Player) {
         state.selected_tab = 0;
         state.selected_row = 0;
     }
-    player.set_crossfade_ms(state.settings.crossfade_ms());
+    player.set_crossfade(state.settings.crossfade_ms(), state.settings.crossfade_user_skips);
 }
 
 /// Persist and decorate the message with the outcome.

--- a/src/tui/logic/input/help_editor.rs
+++ b/src/tui/logic/input/help_editor.rs
@@ -111,19 +111,20 @@ fn handle_settings_input(
     InputOutcome::Continue
 }
 
-/// Move a duration row by `delta` seconds, within its allowed range.
-fn adjust(row: SettingRow, state: &mut AppState, data: &mut AppData, player: &Player, delta: i16) {
+/// Move a duration row by `steps` half-seconds, within its allowed range. The current
+/// value is snapped onto the grid first, so a duration hand-edited to something off it
+/// lands on a round figure rather than carrying the offset for ever.
+fn adjust(row: SettingRow, state: &mut AppState, data: &mut AppData, player: &Player, steps: i8) {
     let SettingRow::Secs(label, field) = row else { return };
+    let snapped = state.settings.crossfade_secs_snapped();
     let secs = {
         let value = field(&mut state.settings);
-        *value = (i16::from(*value) + delta).clamp(
-            i16::from(Settings::CROSSFADE_SECS_MIN),
-            i16::from(Settings::CROSSFADE_SECS_MAX),
-        ) as u8;
+        *value = (snapped + f32::from(steps) * Settings::CROSSFADE_SECS_STEP)
+            .clamp(Settings::CROSSFADE_SECS_MIN, Settings::CROSSFADE_SECS_MAX);
         *value
     };
     apply_settings(state, data, player);
-    state.help_message = Some(saved(state, format!("{label}: {secs}s")));
+    state.help_message = Some(saved(state, format!("{label}: {secs:.1}s")));
 }
 
 /// Make a just-changed setting take effect on what is already loaded.

--- a/src/tui/logic/input/history.rs
+++ b/src/tui/logic/input/history.rs
@@ -2,7 +2,7 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent};
 
 use super::InputOutcome;
 use crate::keymap::Action;
-use crate::player::Player;
+use crate::player::{Player, TrackChange};
 use crate::tui::logic::state::{AppData, AppState};
 use crate::tui::logic::utils::{play_queued_track, queued_from_current};
 
@@ -33,7 +33,7 @@ pub(crate) fn handle_history_input(
                 if let Some(current) = queued_from_current(state, data) {
                     state.playback_history.push(current);
                 }
-                play_queued_track(entry, state, data, player, true);
+                play_queued_track(entry, state, data, player, true, TrackChange::UserSkip);
                 state.history_visible = false;
             }
         }

--- a/src/tui/logic/input/mod.rs
+++ b/src/tui/logic/input/mod.rs
@@ -61,7 +61,7 @@ pub fn handle_key_event(
         return quit::handle_quit_confirm(key, state);
     }
     if state.help_visible {
-        return help_editor::handle_help_input(key, state, data);
+        return help_editor::handle_help_input(key, state, data, player);
     }
     if state.theme_picker_visible {
         return theme_picker::handle_theme_picker_input(key, state);

--- a/src/tui/logic/input/navigation.rs
+++ b/src/tui/logic/input/navigation.rs
@@ -1,6 +1,6 @@
 use super::InputOutcome;
 use super::helpers::reset_search_rows;
-use crate::player::Player;
+use crate::player::{Player, TrackChange};
 use crate::tui::logic::state::{AppData, AppState, visible_tabs};
 use crate::tui::logic::utils::{active_tracks, build_queue, build_search_matches};
 
@@ -163,13 +163,20 @@ pub(crate) fn handle_next_track(
             if let Some(current) = crate::tui::logic::utils::queued_from_current(state, data) {
                 state.playback_history.push(current);
             }
-            crate::tui::logic::utils::play_queued_track(queued, state, data, player, true);
+            crate::tui::logic::utils::play_queued_track(
+                queued,
+                state,
+                data,
+                player,
+                true,
+                TrackChange::UserSkip,
+            );
         } else if let Some(next_idx) = state.auto_queue.pop_front()
             && let Some(track) = active_tracks.get(next_idx) {
                 if let Some(current) = crate::tui::logic::utils::queued_from_current(state, data) {
                     state.playback_history.push(current);
                 }
-                player.play(track.clone());
+                player.play(track.clone(), TrackChange::UserSkip);
                 state.override_playing = None;
                 state.current_playing_index = Some(next_idx);
             }
@@ -189,7 +196,14 @@ pub(crate) fn handle_prev_track(
                 current.user_added = false;
                 state.manual_queue.push_front(current);
             }
-            crate::tui::logic::utils::play_queued_track(prev, state, data, player, true);
+            crate::tui::logic::utils::play_queued_track(
+                prev,
+                state,
+                data,
+                player,
+                true,
+                TrackChange::UserSkip,
+            );
         }
     InputOutcome::Continue
 }

--- a/src/tui/logic/input/playback.rs
+++ b/src/tui/logic/input/playback.rs
@@ -2,7 +2,7 @@ use super::InputOutcome;
 use super::helpers::filtered_row;
 use crate::api::{Artist, Track};
 use crate::tui::logic::state::{AppData, AppState, PlaybackSource, FollowingTracksFocus};
-use crate::player::Player;
+use crate::player::{Player, TrackChange};
 use crate::tui::logic::utils::{build_queue, enter_radio, queued_from_current};
 
 use super::queue::selected_queued;
@@ -67,7 +67,7 @@ pub(crate) fn handle_station(
         state.playback_history.push(current);
     }
     state.manual_queue.clear();
-    player.play(queued.track.clone());
+    player.play(queued.track.clone(), TrackChange::UserSkip);
     enter_radio(state, data, vec![queued.track]);
     InputOutcome::Continue
 }
@@ -113,7 +113,7 @@ fn start_playback(
             state.playback_history.push(queued);
         }
 
-    player.play(track.clone());
+    player.play(track.clone(), TrackChange::UserSkip);
     state.playback_source = source;
     state.override_playing = None;
     state.current_playing_index = Some(idx);

--- a/src/tui/logic/mod.rs
+++ b/src/tui/logic/mod.rs
@@ -45,7 +45,7 @@ use crate::media::{Media, MediaCommand};
 use self::state::{AppData, AppState, Engagement, LyricsStatus, PlaybackSource, PlaylistEdit};
 use self::utils::{
     enter_radio,
-    active_tracks, append_feed_tracks, play_queued_track, queued_from_current,
+    active_tracks, append_feed_tracks, next_track_trigger_ms, play_queued_track, queued_from_current,
 };
 
 /// How long a track must have been playing before its lyrics are looked up.
@@ -240,6 +240,7 @@ fn start(
     state.theme_name = config.theme_name;
     state.theme_overrides = config.theme_overrides;
     state.settings = config.settings;
+    player.set_crossfade_ms(state.settings.crossfade_ms());
 
     let mut api_guard = api.lock().unwrap();
     let mut data = AppData::new(&mut api_guard, state.selected_row)?;
@@ -1045,7 +1046,16 @@ fn start(
 
             let current_track = player.current_track();
             if is_playing && !current_track.track_urn.is_empty() {
-                let preload_threshold = (current_track.duration_ms as f64 * 0.8) as u64;
+                // Repeat replays the same track, which the player reads as a seek
+                // rather than a track change, so there is nothing to overlap.
+                // ponytail: give `play_from_position` the caller's intent instead
+                // of inferring it from the URN if repeat ever wants a crossfade.
+                let crossfade_ms = if state.repeat_enabled { 0 } else { state.settings.crossfade_ms() };
+                let handover_ms = next_track_trigger_ms(current_track.duration_ms, crossfade_ms);
+                // Whichever comes first: the usual four fifths in, or long enough
+                // before the handover that a crossfade has the next track ready.
+                let preload_threshold = ((current_track.duration_ms as f64 * 0.8) as u64)
+                    .min(handover_ms.saturating_sub(10_000));
                 let should_preload = state.progress >= preload_threshold 
                     && state.progress < current_track.duration_ms.saturating_sub(100)
                     && state.preload_triggered_for_track_urn.as_deref() != Some(current_track.track_urn.as_str());
@@ -1085,8 +1095,7 @@ fn start(
                     state.preload_triggered_for_track_urn = None;
                 }
 
-                let at_end = state.progress >= current_track.duration_ms.saturating_sub(50)
-                    && current_track.duration_ms > 0;
+                let at_end = state.progress >= handover_ms && current_track.duration_ms > 0;
 
                 if !at_end {
                     state.end_handled_track_urn = None;

--- a/src/tui/logic/mod.rs
+++ b/src/tui/logic/mod.rs
@@ -12,7 +12,7 @@ use crate::api::{
     fetch_user_tracks,
 };
 use crate::auth::Token;
-use crate::player::Player;
+use crate::player::{Player, TrackChange};
 use rand::seq::SliceRandom;
 use ratatui::crossterm::{
     event::{KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
@@ -240,7 +240,7 @@ fn start(
     state.theme_name = config.theme_name;
     state.theme_overrides = config.theme_overrides;
     state.settings = config.settings;
-    player.set_crossfade_ms(state.settings.crossfade_ms());
+    player.set_crossfade(state.settings.crossfade_ms(), state.settings.crossfade_user_skips);
 
     let mut api_guard = api.lock().unwrap();
     let mut data = AppData::new(&mut api_guard, state.selected_row)?;
@@ -400,7 +400,7 @@ fn start(
                             if let Some(current) = queued_from_current(&state, &data) {
                                 state.playback_history.push(current);
                             }
-                            player.play(track);
+                            player.play(track, TrackChange::Natural);
                             state.override_playing = None;
                             state.current_playing_index = Some(next_idx);
                             state.radio_waiting = false;
@@ -415,7 +415,7 @@ fn start(
                             state.playback_history.push(current);
                         }
                         state.manual_queue.clear();
-                        player.play(seed);
+                        player.play(seed, TrackChange::UserSkip);
                         enter_radio(&mut state, &mut data, tracks);
                     }
                 }
@@ -1046,10 +1046,11 @@ fn start(
 
             let current_track = player.current_track();
             if is_playing && !current_track.track_urn.is_empty() {
-                // Repeat replays the same track, which the player reads as a seek
-                // rather than a track change, so there is nothing to overlap.
-                // ponytail: give `play_from_position` the caller's intent instead
-                // of inferring it from the URN if repeat ever wants a crossfade.
+                // Repeat replays the same track, which the player still reads as a
+                // seek (same urn) rather than a track change, so there is nothing to
+                // overlap even though the intent now reaches the engine.
+                // ponytail: repeat would need a second decode of the same track to
+                // fade into itself; do that only if anyone asks for it.
                 let crossfade_ms = if state.repeat_enabled { 0 } else { state.settings.crossfade_ms() };
                 let handover_ms = next_track_trigger_ms(current_track.duration_ms, crossfade_ms);
                 // Whichever comes first: the usual four fifths in, or long enough
@@ -1105,20 +1106,27 @@ fn start(
                     if let Some(current_idx) = state.current_playing_index {
                         if state.repeat_enabled {
                         if let Some(track) = active_tracks(&state, &data).get(current_idx) {
-                            player.play(track.clone());
+                            player.play(track.clone(), TrackChange::Natural);
                             state.override_playing = None;
                         }
                         } else if let Some(queued) = state.manual_queue.pop_front() {
                         if let Some(current) = queued_from_current(&state, &data) {
                             state.playback_history.push(current);
                         }
-                            play_queued_track(queued, &mut state, &mut data, &player, true);
+                            play_queued_track(
+                                queued,
+                                &mut state,
+                                &mut data,
+                                &player,
+                                true,
+                                TrackChange::Natural,
+                            );
                         } else if let Some(next_idx) = state.auto_queue.pop_front() {
                             if let Some(track) = active_tracks(&state, &data).get(next_idx) {
                                 if let Some(current) = queued_from_current(&state, &data) {
                                     state.playback_history.push(current);
                                 }
-                                player.play(track.clone());
+                                player.play(track.clone(), TrackChange::Natural);
                                 state.override_playing = None;
                                 state.current_playing_index = Some(next_idx);
                             }

--- a/src/tui/logic/state.rs
+++ b/src/tui/logic/state.rs
@@ -370,6 +370,17 @@ pub enum HelpPage {
 }
 
 impl HelpPage {
+    /// The popup's tab bar, in order.
+    pub const TITLES: [&'static str; 3] = ["Keys", "Settings", "Equaliser"];
+
+    pub fn index(self) -> usize {
+        match self {
+            Self::Keys => 0,
+            Self::Settings => 1,
+            Self::Equalizer => 2,
+        }
+    }
+
     pub fn next(self) -> Self {
         match self {
             Self::Keys => Self::Settings,

--- a/src/tui/logic/utils.rs
+++ b/src/tui/logic/utils.rs
@@ -435,9 +435,30 @@ pub fn queued_from_current(state: &AppState, data: &AppData) -> Option<QueuedTra
     ))
 }
 
+/// When to start the next track. Normally that is the moment this one runs out;
+/// with a crossfade the next one has to start `crossfade_ms` early so the two
+/// overlap. Never earlier than half way through, so a short track (or a long
+/// crossfade) cannot start its successor almost as soon as it begins.
+pub(crate) fn next_track_trigger_ms(duration_ms: u64, crossfade_ms: u64) -> u64 {
+    const END_OF_TRACK_SLACK_MS: u64 = 50;
+    let lead = crossfade_ms.max(END_OF_TRACK_SLACK_MS).min(duration_ms / 2);
+    duration_ms.saturating_sub(lead)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_next_track_starts_early_enough_to_crossfade_but_never_half_way_in() {
+        // No crossfade: unchanged, the old 50 ms of end-of-track slack.
+        assert_eq!(next_track_trigger_ms(200_000, 0), 199_950);
+        // 8 s crossfade over a 3 minute track.
+        assert_eq!(next_track_trigger_ms(180_000, 8_000), 172_000);
+        // A 10 s clip must not hand over 12 s before it ends.
+        assert_eq!(next_track_trigger_ms(10_000, 12_000), 5_000);
+        assert_eq!(next_track_trigger_ms(0, 12_000), 0);
+    }
 
     fn track(urn: &str, access: &str) -> Track {
         Track {

--- a/src/tui/logic/utils.rs
+++ b/src/tui/logic/utils.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use rand::seq::SliceRandom;
 
 use crate::api::{Album, Artist, Playlist, Track};
-use crate::player::Player;
+use crate::player::{Player, TrackChange};
 
 use super::state::{AppData, AppState, FollowingTracksFocus, PlaybackSource, QueuedTrack};
 
@@ -285,12 +285,13 @@ pub fn play_queued_track(
     data: &mut AppData,
     player: &Player,
     preserve_context: bool,
+    change: TrackChange,
 ) {
     if !queued.track.is_playable() {
         return;
     }
 
-    player.play(queued.track.clone());
+    player.play(queued.track.clone(), change);
     state.override_playing = Some(queued.clone());
     if preserve_context {
         return;

--- a/src/tui/render/overlays/help.rs
+++ b/src/tui/render/overlays/help.rs
@@ -17,13 +17,12 @@ use super::utils::centered_rect;
 /// settings page.
 pub fn render_help(frame: &mut Frame, state: &AppState) {
     if state.help_settings {
-        let mut settings = state.settings;
         let rows: Vec<Row> = Settings::ROWS
             .iter()
-            .map(|(label, field)| {
-                let on = *field(&mut settings);
-                let row = Row::new(vec![label.to_string(), if on { "on" } else { "off" }.to_string()]);
-                if on {
+            .map(|setting| {
+                let (value, in_effect) = setting.display(state.settings);
+                let row = Row::new(vec![setting.label().to_string(), value]);
+                if in_effect {
                     row
                 } else {
                     row.style(Style::default().fg(theme::current().dim))
@@ -37,7 +36,7 @@ pub fn render_help(frame: &mut Frame, state: &AppState) {
             &["Setting", "State"],
             rows,
             state.help_settings_selected,
-            "Enter/Space: toggle   ↑↓: move   Tab: keys   Esc: close",
+            "Enter/Space: toggle   ←→: adjust   ↑↓: move   Tab: keys   Esc: close",
         );
         return;
     }

--- a/src/tui/render/overlays/help.rs
+++ b/src/tui/render/overlays/help.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Row, Table, TableState},
+    widgets::{Block, Borders, Clear, Paragraph, Row, Table, TableState, Tabs, Wrap},
 };
 use crate::theme;
 
@@ -15,15 +15,14 @@ use crate::tui::render::utils::styled_header;
 
 use super::utils::{centered_rect, centered_rect_fixed};
 
-/// Key reference and editor, generated from the live keymap. Tab cycles it through
-/// the settings and equaliser pages.
+/// Key reference and editor, generated from the live keymap. A tab bar across the
+/// top names the pages; Tab cycles through them.
 pub fn render_help(frame: &mut Frame, state: &AppState) {
     if state.help_page == HelpPage::Equalizer {
         let body = render_shell(
             frame,
             state,
-            " Equaliser ",
-            "↑↓: adjust   ←→: band   r: flat   Tab: keys   Esc: close",
+            "↑↓: adjust   ←→: band   r: flat   Tab: page   Esc: close",
         );
         render_bands(frame, body, state.eq.gains, state.help_eq_selected);
         return;
@@ -45,11 +44,10 @@ pub fn render_help(frame: &mut Frame, state: &AppState) {
         render_page(
             frame,
             state,
-            " Settings ",
             &["Setting", "State"],
             rows,
             state.help_settings_selected,
-            "Enter/Space: toggle   ←→: adjust   ↑↓: move   Tab: equaliser   Esc: close",
+            "Enter/Space: toggle   ←→: adjust   ↑↓: move   Tab: page   Esc: close",
         );
         return;
     }
@@ -68,11 +66,10 @@ pub fn render_help(frame: &mut Frame, state: &AppState) {
     render_page(
         frame,
         state,
-        " Keys ",
         &["Action", "Keys"],
         rows,
         state.help_selected,
-        "Enter: add key   Backspace: unbind   r: default   ↑↓: move   Tab: settings   Esc: close   ·  saved to ~/.config/sctui/config.toml",
+        "Enter: add key   Backspace: unbind   r: default   ↑↓: move   Tab: page   Esc: close   ·  saved to ~/.config/sctui/config.toml",
     );
 }
 
@@ -180,13 +177,12 @@ fn gain_label(db: i8, units: bool) -> String {
 fn render_page(
     frame: &mut Frame,
     state: &AppState,
-    title: &str,
     header: &[&str],
     rows: Vec<Row>,
     selected: usize,
     hint: &str,
 ) {
-    let table_area = render_shell(frame, state, title, hint);
+    let table_area = render_shell(frame, state, hint);
     let table = Table::new(rows, vec![Constraint::Percentage(62), Constraint::Percentage(38)])
         .header(styled_header(header))
         .column_spacing(1)
@@ -200,25 +196,50 @@ fn render_page(
     frame.render_stateful_widget(table, table_area, &mut table_state);
 }
 
-/// The popup frame every page shares: border, status line and hint line. Returns
-/// the area left over for the page's own body.
-fn render_shell(frame: &mut Frame, state: &AppState, title: &str, hint: &str) -> Rect {
+/// Lines the hint needs at this width. It is the longest thing on the popup and
+/// a centred single line just loses both ends off the sides, so it wraps instead.
+fn hint_height(hint: &str, width: u16) -> u16 {
+    let width = width.max(1) as usize;
+    (hint.chars().count().div_ceil(width) as u16).clamp(1, MAX_HINT_LINES)
+}
+
+/// Past this the hint would eat the page it belongs to, so it clips after all.
+const MAX_HINT_LINES: u16 = 3;
+
+/// The popup frame every page shares: border, the page tabs, status line and hint.
+/// Returns the area left over for the page's own body.
+fn render_shell(frame: &mut Frame, state: &AppState, hint: &str) -> Rect {
     let popup_area = centered_rect(76, 80, frame.area());
     frame.render_widget(Clear, popup_area);
 
     let block = Block::default()
-        .title(title)
+        .title(" Help ")
         .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_type(ratatui::widgets::BorderType::Rounded);
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
-    let [body_area, status_area, hint_area] = Layout::vertical([
+    let [tabs_area, body_area, status_area, hint_area] = Layout::vertical([
+        Constraint::Length(2),
         Constraint::Fill(1),
         Constraint::Length(1),
-        Constraint::Length(1),
+        Constraint::Length(hint_height(hint, inner.width)),
     ])
     .areas(inner);
+
+    // The same switcher the main window uses for Library/Search/Feed, minus its
+    // block: the popup's own border is already around it.
+    let tabs: Vec<_> = HelpPage::TITLES.iter().map(|t| Span::raw(*t)).collect();
+    frame.render_widget(
+        Tabs::new(tabs)
+            .block(Block::default().borders(Borders::BOTTOM))
+            .select(state.help_page.index())
+            .style(Style::default().fg(theme::current().fg))
+            .highlight_style(
+                Style::default().fg(theme::current().accent).add_modifier(Modifier::BOLD),
+            ),
+        tabs_area,
+    );
 
     let (status, status_style) = match (&state.help_capture, &state.help_message) {
         (Some(_), Some(msg)) => (msg.clone(), Style::default().fg(theme::current().warning).add_modifier(Modifier::BOLD)),
@@ -229,7 +250,8 @@ fn render_shell(frame: &mut Frame, state: &AppState, title: &str, hint: &str) ->
     frame.render_widget(
         Paragraph::new(hint)
             .style(Style::default().fg(theme::current().dim))
-            .alignment(Alignment::Center),
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true }),
         hint_area,
     );
     body_area
@@ -273,6 +295,63 @@ mod tests {
         row[..row.find(label).unwrap()].chars().count() + 2
     }
 
+    /// One page of the popup, as text plus the columns drawn in the accent colour.
+    fn page(width: u16, height: u16, page: HelpPage) -> (String, Vec<u16>) {
+        let state = AppState { help_page: page, ..Default::default() };
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| render_help(f, &state)).unwrap();
+        let buf = terminal.backend().buffer();
+        let text = (0..height)
+            .map(|y| (0..width).map(|x| buf[(x, y)].symbol().to_string()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let accent = theme::current().accent;
+        let accented = (0..width)
+            .filter(|&x| (0..height).any(|y| buf[(x, y)].fg == accent))
+            .collect();
+        (text, accented)
+    }
+
+    #[test]
+    fn the_tab_bar_names_every_page_and_marks_the_current_one() {
+        let (s, accented) = page(100, 30, HelpPage::Settings);
+        let bar = s.lines().find(|l| l.contains("Equaliser")).expect("a tab bar");
+        for title in HelpPage::TITLES {
+            assert!(bar.contains(title), "{title} missing from the tab bar: {bar:?}");
+        }
+
+        // "Settings" is the open page, so it is the accented one, not "Keys".
+        let col_of = |needle: &str| bar[..bar.find(needle).unwrap()].chars().count() as u16;
+        let (settings, keys) = (col_of("Settings"), col_of("Keys"));
+        assert!(accented.contains(&settings), "the open page is not highlighted");
+        assert!(!accented.contains(&keys), "a closed page is highlighted");
+    }
+
+    /// The keys hint is longer than the popup is wide; centred on one line it used
+    /// to lose both ends off the sides.
+    #[test]
+    fn a_hint_too_long_for_one_line_wraps_rather_than_clipping() {
+        let (s, _) = page(100, 30, HelpPage::Keys);
+        assert!(s.contains("Enter: add key"), "the start of the hint is missing");
+        assert!(s.contains("config.toml"), "the end of the hint was clipped");
+
+        // Every row of the popup still has its two borders and nothing overflowed
+        // them. The tab bar is exempt: it draws the same glyph between page names.
+        let is_tab_bar = |l: &str| HelpPage::TITLES.iter().all(|t| l.contains(t));
+        for line in s.lines().filter(|l| l.contains('\u{2502}') && !is_tab_bar(l)) {
+            assert_eq!(line.matches('\u{2502}').count(), 2, "border broken: {line:?}");
+        }
+    }
+
+    #[test]
+    fn hint_height_grows_with_the_text_and_then_stops() {
+        assert_eq!(hint_height("short", 40), 1);
+        assert_eq!(hint_height(&"x".repeat(41), 40), 2);
+        assert_eq!(hint_height(&"x".repeat(10_000), 40), MAX_HINT_LINES);
+        // A zero-width popup must not divide by zero; it saturates like any other.
+        assert_eq!(hint_height("anything", 0), MAX_HINT_LINES);
+    }
+
     #[test]
     fn faders_are_vertical_and_centred() {
         let (s, highlighted) = screen(80, 24, [12, -12, 3, 0, -5, 1], 0);
@@ -283,10 +362,12 @@ mod tests {
         let inside = |l: &str| l.trim_matches(|c| c == ' ' || c == '│').to_string();
         let zero = lines
             .iter()
+            .skip(gains)
             .position(|l| {
                 let l = inside(l);
                 !l.is_empty() && l.chars().all(|c| c == '─')
             })
+            .map(|row| row + gains)
             .unwrap();
         let bands = lines.iter().position(|l| l.contains("230 Hz")).unwrap();
         assert!(gains < zero && zero < bands, "{s}");

--- a/src/tui/render/overlays/help.rs
+++ b/src/tui/render/overlays/help.rs
@@ -196,6 +196,13 @@ fn render_page(
     frame.render_stateful_widget(table, table_area, &mut table_state);
 }
 
+/// Width `Tabs` draws for the popup's pages: each title padded a space either side,
+/// with a one-cell divider between them.
+fn tab_bar_width() -> u16 {
+    let titles: u16 = HelpPage::TITLES.iter().map(|t| t.chars().count() as u16 + 2).sum();
+    titles + HelpPage::TITLES.len() as u16 - 1
+}
+
 /// Lines the hint needs at this width. It is the longest thing on the popup and
 /// a centred single line just loses both ends off the sides, so it wraps instead.
 fn hint_height(hint: &str, width: u16) -> u16 {
@@ -212,9 +219,9 @@ fn render_shell(frame: &mut Frame, state: &AppState, hint: &str) -> Rect {
     let popup_area = centered_rect(76, 80, frame.area());
     frame.render_widget(Clear, popup_area);
 
+    // No title: the tab bar below names the page, and a heading over it said nothing
+    // the tabs do not.
     let block = Block::default()
-        .title(" Help ")
-        .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .border_type(ratatui::widgets::BorderType::Rounded);
     let inner = block.inner(popup_area);
@@ -227,18 +234,21 @@ fn render_shell(frame: &mut Frame, state: &AppState, hint: &str) -> Rect {
     ])
     .areas(inner);
 
-    // The same switcher the main window uses for Library/Search/Feed, minus its
-    // block: the popup's own border is already around it.
+    // The same switcher the main window uses for Library/Search/Feed, centred over a
+    // rule. `Tabs` has no alignment of its own, so it is given exactly the width it
+    // draws and that is centred instead.
+    let rule = Block::default().borders(Borders::BOTTOM);
+    let tabs_line = rule.inner(tabs_area);
+    frame.render_widget(rule, tabs_area);
     let tabs: Vec<_> = HelpPage::TITLES.iter().map(|t| Span::raw(*t)).collect();
     frame.render_widget(
         Tabs::new(tabs)
-            .block(Block::default().borders(Borders::BOTTOM))
             .select(state.help_page.index())
             .style(Style::default().fg(theme::current().fg))
             .highlight_style(
                 Style::default().fg(theme::current().accent).add_modifier(Modifier::BOLD),
             ),
-        tabs_area,
+        centered_rect_fixed(tab_bar_width(), 1, tabs_line),
     );
 
     let (status, status_style) = match (&state.help_capture, &state.help_message) {
@@ -325,6 +335,29 @@ mod tests {
         let (settings, keys) = (col_of("Settings"), col_of("Keys"));
         assert!(accented.contains(&settings), "the open page is not highlighted");
         assert!(!accented.contains(&keys), "a closed page is highlighted");
+
+        // Centred in the popup, and nothing titling the border above it.
+        let gap = |l: &str| l.chars().filter(|c| *c != '\u{2502}').collect::<String>();
+        let bar = gap(bar);
+        let lead = bar.chars().take_while(|c| *c == ' ').count();
+        let trail = bar.chars().rev().take_while(|c| *c == ' ').count();
+        assert!(lead.abs_diff(trail) <= 1, "the tab bar is not centred: {bar:?}");
+        let border = s.lines().find(|l| l.contains('\u{256d}')).expect("the popup's top border");
+        assert!(
+            border.chars().all(|c| " ╭╮─".contains(c)),
+            "something is titling the popup: {border:?}"
+        );
+    }
+
+    #[test]
+    fn the_tab_bar_width_matches_what_tabs_draws() {
+        // Every page name, each padded a space either side, with dividers between.
+        let (s, _) = page(100, 30, HelpPage::Keys);
+        let bar = s.lines().find(|l| l.contains("Equaliser")).unwrap();
+        // Between the popup's two borders, keeping the dividers between page names.
+        let inner = &bar[bar.find('\u{2502}').unwrap() + 3..bar.rfind('\u{2502}').unwrap()];
+        // Tabs pads either end of its rect with a space, which trimming takes off.
+        assert_eq!(tab_bar_width() as usize, inner.trim().chars().count() + 2);
     }
 
     /// The keys hint is longer than the popup is wide; centred on one line it used


### PR DESCRIPTION
Fixes #45.

Adds a "Crossfade between tracks" toggle, a "Crossfade duration" row (1–12 s, left/right in 1 s steps, `h`/`l` too) and a "Crossfade applies to user-skips" toggle to the settings page of the `?` overlay, saved to `config.toml` alongside the existing toggles.

## Cause

The issue's diagnosis is close but not quite right, and the difference matters for the fix.

- `crossfade_and_stop` did exist, but the only caller was the **seek** path: `src/player/stream/engine.rs:309` was reached only when `is_seek && has_old_sink` (`src/player/stream/engine.rs:300-303` on `main`). A **track change** was a hard cut — `src/player/stream/engine.rs:200-202` stopped the outgoing sink before the replacement was even loaded, so by the time a new sink existed there was nothing left to fade against. The 35 ms fade the issue describes at track switches was never running there.
- Simply lengthening the fade would also not have worked. Everything belonging to a track — its decode thread (`src/player/stream/engine.rs:359` on `main`) and its segment pump (`src/player/stream/downloader.rs:107` on `main`) — stops as soon as the generation counter moves on, and the PCM channel holds about 1.5 s of look-ahead (`src/player/stream/engine.rs:23-25`). An outgoing track would therefore have run dry roughly a second and a half into any longer fade.
- A crossfade at the natural end of a track also needs the next one to start early. The handover fired at `duration_ms - 50 ms` (`src/tui/logic/mod.rs:1088` on `main`), i.e. once the outgoing track was already silent.

## Fix

- `src/config.rs`: `Settings` gains `crossfade` and `crossfade_secs` (default 5, clamped 1–12 on read so a hand-edited file cannot inject a silly value), and `SettingRow` becomes an enum of `Toggle`/`Secs` so the settings page can hold a numeric row. Old config files without the keys still load; the duration row is dimmed while the toggle is off.
- `src/player/{commands,controller,worker}.rs`: the length reaches the player thread as `PlayerCommand::SetCrossfade`, pushed at startup and whenever the setting changes.
- `src/player/stream/engine.rs`: on a track change with crossfading on, the outgoing sink is left playing, the incoming one starts at zero volume, and a background thread ramps them past each other on an equal-power curve before stopping and dropping the old sink. A new `fading` generation grants exactly one superseded track the reprieve it needs to keep decoding and downloading until its fade ends (`is_live`), so it does not run out of audio mid-fade. The fade runs off the player thread, so a 12 s crossfade does not block pause/skip/volume for 12 s, and it follows pause/resume. A track change that fails part way now goes through `abort_switch`, which stops the outgoing track rather than leaving it playing under a player that reports itself idle.
- `src/player/stream/sample.rs`: the visualizer tap only writes while its track is the current generation — two tracks pushing into the same wave buffer would interleave into noise for the whole fade.
- `src/tui/logic/{utils,mod}.rs`: `next_track_trigger_ms` moves the handover to `crossfade` before the end (never earlier than half way through, so a short track or a long crossfade cannot hand over almost immediately), and the preload is pulled forward to match.

### "Crossfade applies to user-skips"

The third row decides whether the crossfade covers changes the user asked for, or only a track ending of its own accord.

- **On (default):** every track change crossfades — the queue moving on, next/prev, Enter on a row, an entry picked out of the history popup, an artist station.
- **Off:** only a natural handover crossfades. A user-initiated change is a hard cut, exactly as it behaves today with crossfading disabled.

**Default on.** Someone who has just switched "Crossfade between tracks" on has asked for tracks to blend into each other; having half of the changes they make still cut hard is the more surprising of the two, and it is what the crossfade setting in every other player does. Off is there for people who want a skip to feel immediate.

**Seeks are unaffected either way** — fast-forward and rewind keep their own 35 ms click-avoidance fade whatever these settings say.

The engine could not tell a natural handover from a user skip (it only knew "same urn = seek"), so the intent is now carried rather than inferred:

- `TrackChange` (`Natural` / `UserSkip` / `Seek`) is a new payload on `PlayerCommand::Play` and a parameter of `play_from_position`; the fast-forward and rewind paths in `worker.rs` pass `Seek` explicitly. `Player::play` takes it, and so does `play_queued_track`, which is reached both from the end-of-track handover (`Natural`) and from next/prev/history (`UserSkip`) — threaded once, not guessed per call site.
- `PlayerCommand::SetCrossfade` carries `on_user_skips` alongside `ms`, so both halves of the setting reach the engine by the same route as before (startup and every settings change).
- `crossfade_applies(crossfade_ms, on_user_skips, change)` in `engine.rs` is the single place that decides whether a change overlaps; `overlap` is now just `has_old_sink && crossfade_applies(..)`.
- The engine still folds a same-urn `Play` down to `Seek` before asking, so repeat-one behaves exactly as it did.
- `src/config.rs`: `crossfade_user_skips` (default `true`) in `[settings]`, and a `SettingRow::CrossfadeToggle` variant so the row is dimmed alongside the duration whenever crossfading is off — the same "not in effect" treatment the duration row already gets, rather than a new kind of hint.

With crossfading off, behaviour is unchanged: the handover stays at 50 ms, a track change is still a clean stop, and the 35 ms click-avoidance fade stays as the floor on the path that actually uses it (seeks) — it is also the minimum for the switch path. I did not add a 35 ms overlap to switches with crossfading off: that would mean deferring the stop until after the (possibly slow) load, so pressing next would audibly keep playing the old track while the next one buffers.

## Tests

`cargo test`: 65 passed, 0 failed, 3 ignored (up from 62 on `main`; the fixture-backed decode test still skips without `SCTUI_FIXTURE_DIR`). New checks:

- `config::tests::crossfade_duration_defaults_and_clamps` — old config files default, nonsense durations clamp.
- `config::tests::settings_round_trip` — extended to the new rows.
- `player::stream::engine::tests` — the crossfade curve holds constant power and ends swapped over, a lone fade just ramps down, the step schedule stays bounded and still gives the 35 ms fade its original 7×5 ms, and only the current and fading-out generations count as live.
- `player::stream::sample::tests::a_superseded_track_keeps_playing_but_stops_feeding_the_visualizer`.
- `tui::logic::utils::tests::the_next_track_starts_early_enough_to_crossfade_but_never_half_way_in`.
- `player::stream::engine::tests::the_crossfade_setting_decides_which_changes_overlap` — the decision is a pure function of (length, user-skip setting, change kind): nothing overlaps with crossfading off, a natural handover always overlaps, a user skip only when the setting says so, and a seek never does either way.
- `config::tests::the_user_skip_row_is_dimmed_until_crossfading_is_on`.

`cargo clippy --quiet --all-targets`: same 21 warnings as `origin/main`, none new (compared warning-for-warning ignoring line numbers). No new warnings in any file touched here. The pre-existing `too_many_arguments` warning on `play_from_position` goes from 8/7 to 9/7 arguments — same warning, one argument worse; a params struct like `SegmentPumpParams` would silence it if that ever matters. `cargo fmt` deliberately not run.

## Not done

- **Nothing here was heard.** There is no SoundCloud session available in this environment, so no audio path was exercised and the real TUI could not be driven: the overlap, the equal-power curve, the early handover, the pause-during-fade behaviour and the hard cut on a skip with the new setting off are reasoned from the code and covered only by unit tests on the pure parts.
- Repeat-one does not crossfade. The caller's intent now does reach the engine, but replaying the same track is still folded down to a seek, so the handover stays at the end of the track when repeat is on. `ponytail:` comment updated: fading a track into itself needs a second decode of the same track, which is not worth building until someone asks.
- A volume change made during a long crossfade is overwritten by the ramp until the fade finishes (`ponytail:` comment on `Fade::target_volume`).
- The visualizer follows the incoming track for the whole fade rather than showing the mix.
- The README is untouched: it does not document the existing settings toggles either.

