### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,7 +3053,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sctui"
-version = "0.2.0"
+version = "0.3.0"
 description = "a soundcloud client for the terminal"
 authors = ["Will Murphy <illogicallledits@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Version bump only — `Cargo.toml` and `Cargo.lock`, nothing else. Merging this and then pushing a `v0.3.0` tag runs the release workflow: it checks the tag matches `Cargo.toml`, tests on all three OSes, builds the five targets, smoke-installs each archive through the real installer scripts, and only then publishes the release.

## What ships in v0.3.0

- **#51** — Resuming after a long pause or laptop sleep no longer plays one buffered chunk and goes silent. The segment pump re-resolves the HLS manifest when its signed URLs expire instead of retrying a dead 403 forever.
- **#52** — Holding ↑/↓ accelerates from one row to ten after a grace period, on the main list and the second and third panes.
- **#53** — Settings toggles to hide unplayable tracks and to hide the feed tab. Hidden rows come back when the setting is switched off.
- **#60** — Six-band equaliser page in the `?` overlay, ±12 dB, applied live to what is playing and persisted to `[eq]`.
- **#61** — Configurable crossfade: on/off, 0.5–12s in half-second steps, and whether it applies to user-skips as well as tracks ending naturally. The `?` overlay also gained a centred tab bar and a hint line that wraps instead of clipping.

## Worth knowing before tagging

The audio work in #60 and #61 was written without a live SoundCloud session available to the agents that wrote it, so its verification is unit tests plus a listen by the maintainer rather than automated coverage.

Compliance issues #54–#59 (attribution, 429 handling, cover-art temp files, search debounce, token file permissions, committed Cloudflare metadata) are **not** in this release. #54 and #55 in particular are the SoundCloud API Terms items worth prioritising for 0.3.1.